### PR TITLE
logging.critical -> sys.exit because logging.critical doesn't actually exit

### DIFF
--- a/tools/wheel_resolver/src/resolve.py
+++ b/tools/wheel_resolver/src/resolve.py
@@ -14,6 +14,7 @@ def download(url):
     output = os.environ.get("OUTS")
     if output is None:
         logging.critical("No output directory found")
+        sys.exit(1)
 
     urllib.request.urlretrieve(url, output)
 
@@ -47,14 +48,16 @@ def main():
     # Fetch all available wheel urls from index
     urls = tg.get_download_urls(args.package, args.version)
     if urls is None:
-        sys.exit("No matching urls found in index")
+        logging.critical("No matching urls found in index")
+        sys.exit(1)
 
     result = tg.get_url(urls, args.arch)
 
     if result is not None:
         download(result)
     else:
-        sys.exit('Found %s urls but none are compatible', len(urls))
+        logging.critical("Found %s urls but none are compatible", len(urls))
+        sys.exit(1)
 
 
 main()

--- a/tools/wheel_resolver/src/resolve.py
+++ b/tools/wheel_resolver/src/resolve.py
@@ -7,6 +7,7 @@ import urllib.request
 import os
 import tools.wheel_resolver.src.wheel_tags.tags as tg
 import argparse as argparse
+import sys
 
 
 def download(url):
@@ -46,14 +47,14 @@ def main():
     # Fetch all available wheel urls from index
     urls = tg.get_download_urls(args.package, args.version)
     if urls is None:
-        logging.critical("Couldn't find any matching urls in the index")
+        sys.exit("No matching urls found in index")
 
     result = tg.get_url(urls, args.arch)
 
     if result is not None:
         download(result)
     else:
-        logging.critical('Found %s urls but none are compatible', len(urls))
+        sys.exit('Found %s urls but none are compatible', len(urls))
 
 
 main()

--- a/tools/wheel_resolver/src/wheel_tags/tags.py
+++ b/tools/wheel_resolver/src/wheel_tags/tags.py
@@ -4,6 +4,7 @@ Some methods for wheel fetching and selection
 
 import logging
 import os
+import sys
 from third_party.python.wheel_filename import parse_wheel_filename
 from third_party.python.packaging import tags
 import third_party.python.distlib.locators as locators
@@ -75,8 +76,7 @@ def get_url(urls, archs):
         if is_wheel_file(url) and is_compatible(get_basename(url), archs):
             return url
 
-    logging.critical("Could not find any urls compatible with the provided system info")
-    return None
+    sys.exit("No urls compatible with the provided system info")
 
 
 def get_download_urls(package, version=None):

--- a/tools/wheel_resolver/src/wheel_tags/tags.py
+++ b/tools/wheel_resolver/src/wheel_tags/tags.py
@@ -76,7 +76,8 @@ def get_url(urls, archs):
         if is_wheel_file(url) and is_compatible(get_basename(url), archs):
             return url
 
-    sys.exit("No urls compatible with the provided system info")
+    logging.critical("No urls compatible with the provided system info")
+    sys.exit(1)
 
 
 def get_download_urls(package, version=None):


### PR DESCRIPTION
I was using logging.critical under the assumption that it exits the program with a message, but it doesn't do that. At the moment we get really convoluted output that's difficult to understand. Better to exit with a simple message using sys.exit().

Hopefully this addresses #32 