### PR TITLE
Change wheel_resolver e2e test package

### DIFF
--- a/tools/wheel_resolver/test/BUILD
+++ b/tools/wheel_resolver/test/BUILD
@@ -10,7 +10,7 @@ gentest(
     name = "e2e_test",
     data = ["//tools/wheel_resolver:wheel_resolver"],
     no_test_output = True,
-    test_cmd = "PKG=tensorflow; export OUTS=$PKG.whl; $DATA --package \"$PKG\"; \
+    test_cmd = "PKG=xcrypto; export OUTS=$PKG.whl; $DATA --package \"$PKG\" --version 1.3.1; \
                 if [[ -f \"$PKG\".whl ]]; then exit 0; else exit 1; fi;",
 )
 


### PR DESCRIPTION
This e2e test is bad because it depends on your cpython version. It fails on our work machines. Given that with this test we're only testing if the wheel resolver binary works, we shouldn't be downloading anything complicated. I.e. it should just work and not be machine-specific.