### PR TITLE
Import not working when building pex tool from host repo

### DIFF
--- a/tools/please_pex/pex_main.go
+++ b/tools/please_pex/pex_main.go
@@ -4,8 +4,9 @@ package main
 import (
 	"gopkg.in/op/go-logging.v1"
 
+	"tools/please_pex/pex"
+
 	cli "github.com/peterebden/go-cli-init/v5/flags"
-	"github.com/please-build/python-rules/tools/please_pex/pex"
 )
 
 var log = logging.MustGetLogger("please_pex")


### PR DESCRIPTION
Not sure about this one. Came across this while trying to build from a host repo, and this change resolves the import error. Looking at the build environment, the import shows up in the `importconfig` file as `tools/please_pex/pex`. Can't see how this could possibly be OS-related but FWIW was trying to build on darwin, and I've never seen this on linux. Or might be to do with the fact that I was using the go plugin.

Need to confirm what the issue is, but will leave this up as a draft in the meantime.