### PR TITLE
Upgrade pytest to version 7.2.0

### DIFF
--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -424,10 +424,18 @@ def pip_library(name:str, version:str, hashes:list=None, package_name:str=None,
         # Unfortunately it does *not* work similarly on the Debian problem :(
         pip_cmd = 'echo "[install]\nprefix=" > setup.cfg; ' + pip_cmd
     if CONFIG.OS == 'linux' and CONFIG.PYTHON.DISABLE_VENDOR_FLAGS == "false":
-        # Fix for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892
-        # tl;dr: Debian has broken --target with a custom patch, the only way to fix is to pass --system
-        # which is itself Debian-specific, so we need to find if we're running on Debian. AAAAARGGGHHHH...
-        pip_cmd = f'[ -f /etc/debian_version ] && SYS_FLAG="--system" || SYS_FLAG=""; {pip_cmd} $SYS_FLAG'
+        # Workaround for https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=830892
+        #
+        # Version 8.1.2-1 of Debian's python3-pip package inverts pip's standard behaviour: --user becomes the default;
+        # a Debian-specific --system option reverts to upstream pip's default behaviour, and it must be passed in order
+        # to use the --target option. python3-pip 18.1-1 changes the behaviour again, implying --user only if --target
+        # is not passed and therefore removing the need to pass --system (although it can still be passed to guarantee
+        # upstream pip's behaviour). python3-pip 21.3.1-1 drops the --system option altogether, and passing it causes
+        # pip to exit with an error).
+        #
+        # The easiest way to deal with this mess is to test whether the pip_tool we're using implements --system, then
+        # to pass it in the real pip invocation if so.
+        pip_cmd = f'[ -f /etc/debian_version ] && {pip_tool} --system >/dev/null 2>&1 && SYS_FLAG="--system" || SYS_FLAG=""; {pip_cmd} $SYS_FLAG'
 
     pip_cmd += f' {repo_flag} {index_flag} {pip_flags} {package_name}'
 

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -136,32 +136,32 @@ if is_platform(
     os = "linux",
 ):
     urls = [
-        "https://files.pythonhosted.org/packages/2f/19/4ebe9fe7006d46dd56eacd8cdc800b465590037bffeea17852520613cfaf/coverage-5.5-cp35-cp35m-manylinux2010_x86_64.whl",
-        "https://files.pythonhosted.org/packages/42/37/a82863f91b41711203277ea286bc37915063f4d1be179ac34b591bf6d8a5/coverage-5.5-cp36-cp36m-manylinux2010_x86_64.whl",
-        "https://files.pythonhosted.org/packages/16/e0/fc9f7bd9b84e6b41d0aad1a113e36714aac0c0a9b307aca5f9af443bc50f/coverage-5.5-cp37-cp37m-manylinux2010_x86_64.whl",
-        "https://files.pythonhosted.org/packages/a4/3a/8f7b217265503eae2b0ea97e714e2709e1e84ee13cd3ca6abdff1e99e76c/coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl",
-        "https://files.pythonhosted.org/packages/a4/79/625f1ed5da2a69f52fb44e0b7ca1b470437ff502348c716005a98a71cd49/coverage-5.5-cp39-cp39-manylinux2010_x86_64.whl",
+        "https://files.pythonhosted.org/packages/0d/ef/8735875a8dc09e1c4e484a5436c8b4148731b70daccc6f203c50b05e7505/coverage-6.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "https://files.pythonhosted.org/packages/bd/a0/e263b115808226fdb2658f1887808c06ac3f1b579ef5dda02309e0d54459/coverage-6.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "https://files.pythonhosted.org/packages/6b/f2/919f0fdc93d3991ca074894402074d847be8ac1e1d78e7e9e1c371b69a6f/coverage-6.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "https://files.pythonhosted.org/packages/3c/7d/d5211ea782b193ab8064b06dc0cc042cf1a4ca9c93a530071459172c550f/coverage-6.5.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+        "https://files.pythonhosted.org/packages/6a/63/8e82513b7e4a1b8d887b4e85c1c2b6c9b754a581b187c0b084f3330ac479/coverage-6.5.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
     ]
 elif is_platform(
     arch = "amd64",
     os = "darwin",
 ):
     urls = [
-        "https://files.pythonhosted.org/packages/9f/16/7e0972f8495f6a1b81cfa6579eead931d63dd445e8ecb3114b04a0e36af2/coverage-5.5-cp35-cp35m-macosx_10_9_x86_64.whl",
-        "https://files.pythonhosted.org/packages/fd/2b/ab03276eb127f8ec7f1cf1499c77944321b125d89859ab51ee7d9f46475f/coverage-5.5-cp36-cp36m-macosx_10_9_x86_64.whl",
-        "https://files.pythonhosted.org/packages/52/44/5df49f3b462a0f5818a2f6f206d6523ff21ff9b21c1eb2906f8a31aa321c/coverage-5.5-cp37-cp37m-macosx_10_9_x86_64.whl",
-        "https://files.pythonhosted.org/packages/b6/26/b53bf0fef1b4bce6f7d61fef10fbf924d943987d4c9e53c394ecebff3673/coverage-5.5-cp38-cp38-macosx_10_9_x86_64.whl",
-        "https://files.pythonhosted.org/packages/0d/8a/3b13c4e1f241a7083a4ee9986b969f0238f41dcd7a8990c786bc3b4b5b19/coverage-5.5-cp39-cp39-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/61/a6/af54588e2091693026df94b09106ee10dcbcdc8c9b2c3989149e6e44a324/coverage-6.5.0-cp37-cp37m-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/05/63/a789b462075395d34f8152229dccf92b25ca73eac05b3f6cd75fa5017095/coverage-6.5.0-cp38-cp38-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/ea/52/c08080405329326a7ff16c0dfdb4feefaa8edd7446413df67386fe1bbfe0/coverage-6.5.0-cp39-cp39-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/c4/8d/5ec7d08f4601d2d792563fe31db5e9322c306848fec1e65ec8885927f739/coverage-6.5.0-cp310-cp310-macosx_10_9_x86_64.whl",
+        "https://files.pythonhosted.org/packages/50/cf/455930004231fa87efe8be06d13512f34e070ddfee8b8bf5a050cdc47ab3/coverage-6.5.0-cp311-cp311-macosx_10_9_x86_64.whl",
     ]
 else:
     urls = [
-        "https://files.pythonhosted.org/packages/93/ac/02bc6a60304a8a58383386f7675f6ebae0d2f49f162dda318e57bd95c746/coverage-5.5-pp37-none-any.whl",
+        "https://files.pythonhosted.org/packages/6e/e6/b31a4b2aa9489da59b35ee0ea4259d6fe9b321a1eaa6492f19342d03d53b/coverage-6.5.0-pp36.pp37.pp38-none-any.whl",
     ]
 
 python_multiversion_wheel(
     name = "coverage",
     urls = urls,
-    version = "5.5",
+    version = "6.5.0",
 )
 
 pip_library(
@@ -226,18 +226,34 @@ pip_library(
     version = "8.2.0",
 )
 
+python_wheel(
+    name = "exceptiongroup",
+    version = "1.0.1",
+)
+
+python_wheel(
+    name = "iniconfig",
+    version = "1.1.1",
+)
+
+python_wheel(
+    name = "tomli",
+    version = "2.0.1",
+)
+
 pip_library(
     name = "pytest",
-    version = "5.4.3",
+    version = "7.2.0",
     deps = [
         ":attrs",
-        ":funcsigs",
-        ":more_itertools",
+        ":exceptiongroup",
+        ":importlib_metadata",
+        ":iniconfig",
         ":packaging",
         ":pkg_resources",
         ":pluggy",
         ":py",
-        ":six",
+        ":tomli",
     ],
 )
 
@@ -483,15 +499,15 @@ filegroup(
     name = "pytest_bootstrap",
     srcs = [
         ":attrs",
-        ":funcsigs",
+        ":exceptiongroup",
         ":importlib_metadata",
-        ":more_itertools",
+        ":iniconfig",
         ":packaging",
         ":pkg_resources",
         ":pluggy",
         ":py",
         ":pytest",
-        ":six",
+        ":tomli",
         ":zipp",
     ],
 )


### PR DESCRIPTION
pytest 5.4.3 isn't compatible with Python 3.10 and newer. Python 3.10 support was officially added in pytest 6.2.5, while Python 3.11 isn't officially supported yet but appears to work correctly as of pytest 7.2.0. Upgrade to version 7.2.0 and pack its new dependencies into the pytest bootstrap pex.

This also requires upgrading coverage from 5.5 to 6.5.0, which drops support for Python 3.5 and 3.6. (Both versions are now end-of-life.)

Fixes https://github.com/thought-machine/please/issues/2570.