### PR TITLE
Remove hashes as we don't have hashes for all platforms

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -38,15 +38,11 @@ python_wheel(
 python_wheel(
     name = "six",
     outs = ["six.py"],
-    hashes = ["8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"],
     version = "1.14.0",
 )
 
 python_wheel(
     name = "requests",
-    hashes = [
-        "43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
-    ],
     version = "2.23.0",
     deps = [
         ":certifi",
@@ -58,38 +54,32 @@ python_wheel(
 
 python_wheel(
     name = "certifi",
-    hashes = ["017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"],
     version = "2019.11.28",
 )
 
 python_wheel(
     name = "chardet",
-    hashes = ["fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"],
     version = "3.0.4",
 )
 
 python_wheel(
     name = "idna",
-    hashes = ["a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"],
     version = "2.9",
 )
 
 python_wheel(
     name = "urllib3",
-    hashes = ["2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"],
     version = "1.25.8",
 )
 
 python_wheel(
     name = "colorlog",
-    hashes = ["732c191ebbe9a353ec160d043d02c64ddef9028de8caae4cfa8bd49b6afed53e"],
     version = "4.1.0",
 )
 
 python_wheel(
     name = "dateutil",
     package_name = "python_dateutil",
-    hashes = ["961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"],
     test_only = True,  # Not used by plz itself.
     version = "2.8.2",
     deps = [":six"],
@@ -140,13 +130,11 @@ python_multiversion_wheel(
 python_wheel(
     name = "attrs",
     outs = ["attr"],
-    hashes = ["08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"],
     version = "19.3.0",
 )
 
 python_wheel(
     name = "pluggy",
-    hashes = ["966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"],
     version = "0.13.1",
     deps = [":importlib_metadata"],
 )
@@ -157,7 +145,6 @@ python_wheel(
         "importlib_metadata",
         "importlib_metadata-1.5.0.dist-info",
     ],
-    hashes = ["b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"],
     patch = "importlib_metadata.patch",
     version = "1.5.0",
     deps = [":zipp"],
@@ -166,32 +153,27 @@ python_wheel(
 python_wheel(
     name = "zipp",
     outs = ["zipp.py"],
-    hashes = ["aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"],
     version = "3.1.0",
 )
 
 python_wheel(
     name = "py",
-    hashes = ["c20fdd83a5dbc0af9efd622bee9a5564e278f6380fffcacc43ba6f43db2813b0"],
     version = "1.8.1",
 )
 
 python_wheel(
     name = "funcsigs",
-    hashes = ["330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca"],
     version = "1.0.2",
 )
 
 python_wheel(
     name = "pkg_resources",
     package_name = "setuptools",
-    hashes = ["c8b9f1a457949002e358fea7d3f2a1e1b94ddc0354b2e40afc066bf95d21bf7b"],
     version = "57.0.0",
 )
 
 python_wheel(
     name = "packaging",
-    hashes = ["170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73"],
     version = "20.1",
 )
 
@@ -202,7 +184,6 @@ pip_library(
 
 python_wheel(
     name = "more_itertools",
-    hashes = ["5dd8bcf33e5f9513ffa06d5ad33d78f31e1931ac9a18f33d37e77a180d393a7c"],
     version = "8.2.0",
 )
 
@@ -212,7 +193,6 @@ python_wheel(
         "_pytest",
         "pytest",
     ],
-    hashes = ["1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"],
     version = "7.1.3",
     deps = [
         ":attrs",
@@ -244,7 +224,6 @@ python_wheel(
     outs = [
         "behave",
     ],
-    hashes = ["ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c"],
     version = "1.2.6",
     deps = [
         ":colorama",
@@ -266,53 +245,45 @@ python_wheel(
     outs = [
         "parse.py",
     ],
-    hashes = ["2bb9c56c65bf609abbbef372bdcdd7b9c163745e7daf5e8217dba50a55850510"],
     version = "1.15.0",
 )
 
 python_wheel(
     name = "parse_type",
-    hashes = ["089a471b06327103865dfec2dd844230c3c658a4a1b5b4c8b6c16c8f77577f9e"],
     version = "0.5.2",
 )
 
 python_wheel(
     name = "traceback2",
-    hashes = ["8253cebec4b19094d67cc5ed5af99bf1dba1285292226e98a31929f87a5d6b23"],
     licences = ["PSF"],
     version = "1.4.0",
 )
 
 python_wheel(
     name = "win_unicode_console",
-    hashes = ["7a7fb8bf98bcacb328d1f607065c0f89107c7e8f4b02caf12e5f02fb462512a6"],
     version = "0.5",
 )
 
 python_wheel(
     name = "enum34",
     outs = ["enum"],
-    hashes = ["708aabfb3d5898f99674c390d360d59efdd08547019763622365f19e84a7fef4"],
     version = "1.1.9",
 )
 
 python_wheel(
     name = "colorama",
-    hashes = ["7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"],
     version = "0.4.3",
 )
 
 python_wheel(
     name = "absl",
     package_name = "absl_py",
-    hashes = ["c106f6ef0ae86c1273b0858b40ee15b99fad1c223838387b9d11446a033bbcb1"],
     version = "0.9.0",
     deps = [":six"],
 )
 
 python_wheel(
     name = "portalocker",
-    hashes = ["874d6063c6ceb185fe4771da41b01872d2c56d292db746698f8ad7bf1833c905"],
     version = "1.7.0",
 )
 
@@ -482,7 +453,6 @@ pip_library(
 
 python_wheel(
     name = "debugpy",
-    hashes = ["f058c204341fd7ff800ee0edafc106ca0fb1c9857e8a8895a6e04cca3ddcb7bf"],
     licences = ["MIT"],
     version = "1.5.0",
 )
@@ -491,20 +461,17 @@ python_wheel(
     name = "typing_extensions",
     outs = ["typing_extensions.py"],
     version = "4.4.0",
-    hashes=["sha256: 16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"],
 )
 
 python_wheel(
     name = "mypy_extensions",
     outs = ["mypy_extensions.py"],
     version = "0.4.3",
-    hashes=["sha256: 090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"],
 )
 
 python_wheel(
     name = "tomli",
     version = "2.0.1",
-    hashes=["sha256: 939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"],
 )
 
 python_wheel(
@@ -512,7 +479,6 @@ python_wheel(
     version = "0.982",
     deps = [":typing_extensions", ":mypy_extensions", ":tomli"],
     binary=True,
-    hashes=["sha256: 1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d"],
 )
 
 filegroup(


### PR DESCRIPTION
Having single hashes means the plugin can fail to build if someone is using the plugin on a platform that we haven't got a hash for.