### PR TITLE
Remove feature flags ahead of v17

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -1,5 +1,5 @@
 [Please]
-Version = 16.21.3
+Version = 17.0.0-beta.1
 
 [Build]
 hashcheckers = sha256
@@ -104,6 +104,4 @@ Inherit = true
 
 [featureflags]
 PythonWheelHashing = true
-ExcludePythonRules = true
-SingleSHA1Hash = true
 ExcludeGoRules = true

--- a/.plzconfig
+++ b/.plzconfig
@@ -17,6 +17,9 @@ gotool = //third_party/go:toolchain|go
 [Plugin "python"]
 DisableVendorFlags = true
 
+[Plugin "shell"]
+Target = //plugins:shell
+
 [PluginDefinition]
 name = python
 

--- a/plugins/BUILD
+++ b/plugins/BUILD
@@ -2,3 +2,8 @@ plugin_repo(
     name = "go",
     revision = "v0.4.1",
 )
+
+plugin_repo(
+    name = "shell",
+    revision = "v0.1.2",
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,4 +1,4 @@
-subinclude("//build_defs:python")
+subinclude("//build_defs:python", "///shell//build_defs:shell")
 
 package(
     default_visibility = ["PUBLIC"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -96,17 +96,6 @@ python_library(
 )
 
 python_test(
-    name = "python2_coverage_test",
-    srcs = ["python_coverage_test.py"],
-    interpreter = "python2",
-    labels = [
-        "py2",
-        "py3",
-    ],
-    deps = [":python_coverage"],
-)
-
-python_test(
     name = "python3_coverage_test",
     srcs = ["python_coverage_test.py"],
     labels = ["py3"],


### PR DESCRIPTION
We shouldn't cut a release here until we've got a non-beta release of v17