### PR TITLE
`python_wheel`: explicitly exit from generated entry point

### DIFF
--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -665,7 +665,7 @@ def _wheel_entrypoint_binary(name:str, entrypoint:str, lib_rule, visibility, tes
     main = text_file(
         name = tag(name, "main"),
         out = f"__{name}_main__.py",
-        content = f"import {module} as m\nm.{func}()",
+        content = f"import sys\nimport {module} as m\nsys.exit(m.{func}())",
         test_only = test_only,
     )
     return python_binary(


### PR DESCRIPTION
Most functions used as entry points explicitly exit (i.e. by calling `sys.exit` directly) with a particular exit code and implicitly return `None`, but the entry points specification also permits entry point functions to return an integer that should be considered an exit code; a notable example is Flake8's CLI function at `flake8.main.cli:main`. The entry point code generated by `python_wheel` does not consume the return value of the entry point function in this way, causing please_pex's `ModuleDirImport` loader to throw an `ImportError` after the generated entry point code has been executed:

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 158, in _get_module_details
    code = loader.get_code(mod_name)
  File "[...]/plz-out/bin/third_party/python3/flake8.pex/__main__.py", line 249, in get_code
    return module.__loader__.get_code(fullname)
  File "<frozen importlib._bootstrap_external>", line 923, in get_code
  File "<frozen importlib._bootstrap_external>", line 527, in _check_name_wrapper
ImportError: loader for __flake8_main__ cannot handle third_party.python3.__flake8_main__
```

In the generated entry point code, explicitly call `sys.exit`, passing it the return value of the entry point function. This is safe for all functions that obey the entry point specification because `sys.exit(None)` is equivalent to `sys.exit(0)`.

Fixes #119.