### PR TITLE
Upgrade importlib-metadata to v6.8.0

### DIFF
--- a/test/importlib_metadata_test.py
+++ b/test/importlib_metadata_test.py
@@ -7,7 +7,7 @@ class ImportlibMetadataTest(unittest.TestCase):
         # pip
         from importlib_metadata import version
 
-        self.assertEqual(version("importlib_metadata"), "1.5.0")
+        self.assertEqual(version("importlib_metadata"), "6.8.0")
 
     def test_nonexistant_module(self):
         from importlib_metadata import distribution, PackageNotFoundError

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -155,11 +155,10 @@ python_wheel(
     name = "importlib_metadata",
     outs = [
         "importlib_metadata",
-        "importlib_metadata-1.5.0.dist-info",
+        "importlib_metadata-6.8.0.dist-info",
     ],
-    hashes = ["b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"],
-    patch = "importlib_metadata.patch",
-    version = "1.5.0",
+    hashes = ["3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb"],
+    version = "6.8.0",
     deps = [":zipp"],
 )
 

--- a/third_party/python/importlib_metadata.patch
+++ b/third_party/python/importlib_metadata.patch
@@ -1,8 +1,0 @@
---- importlib_metadata/__init__.py	2020-03-03 22:11:25.660002895 +0000
-+++ importlib_metadata/__init__.py.new	2020-03-14 11:57:19.600001299 +0000
-@@ -588,4 +588,4 @@
-     return distribution(distribution_name).requires
- 
- 
--__version__ = version(__name__)
-+__version__ = '1.5.0'


### PR DESCRIPTION
The version of importlib-metadata in the bootstrap pex masks all other versions, and v1.5.0 is pretty old now - it's missing functionality required by other modules on PyPi, such as `EntryPoints`. Bump it to the latest version, v6.8.0.

The `__version__` patch is no longer needed because importlib-metadata stopped presenting a `__version__` attribute in v2.0.0.