### PR TITLE
Make in-repo interpreter available to test at runtime

### DIFF
--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -331,7 +331,7 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
     if isinstance(data, dict):
         data['_srcs'] = srcs
     else:
-        data.append(srcs)
+        data.extend(srcs)
 
     if interpreter.startswith('//') or interpreter.startswith(':'):
         if isinstance(data, dict):

--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -326,14 +326,25 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
         pre_cmd = worker_cmd,
     )
 
+    # N.B. the actual test sources are passed as data files as well. This is needed for pytest but
+    #      is faster for unittest as well (because we don't need to rebuild the pex if they change).
+    if isinstance(data, dict):
+        data['_srcs'] = srcs
+    else:
+        data.append(srcs)
+
+    if interpreter.startswith('//') or interpreter.startswith(':'):
+        if isinstance(data, dict):
+            data['_interpreter'] = interpreter
+        else:
+            data.append(interpreter)
+
     # This rule concatenates the .pex with all the other precompiled zip files from dependent rules.
     return build_rule(
         name=name,
         srcs=[pex_rule],
         deps=deps,
-        # N.B. the actual test sources are passed as data files as well. This is needed for pytest but
-        #      is faster for unittest as well (because we don't need to rebuild the pex if they change).
-        data=data | {'_srcs': srcs} if isinstance(data, dict) else data + srcs,
+        data=data,
         outs=[f'{name}.pex'],
         labels=labels + ['test_results_dir'],
         cmd='$TOOL z -i . -s .pex.zip -s .whl --preamble_from="$SRC" --include_other --add_init_py --strict',

--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -333,7 +333,7 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
     else:
         data.extend(srcs)
 
-    if interpreter.startswith('//') or interpreter.startswith(':'):
+    if looks_like_build_label(interpreter):
         if isinstance(data, dict):
             data['_interpreter'] = interpreter
         else:


### PR DESCRIPTION
Currently if you pass an `interpreter` to `python_test` which is the output of a build target, then when run remotely (so that the shebang of the output pex references `/tmp/plz_sandbox` instead of a directory in the local `plz-out`), the test errors because it can't find the interpreter. For example:
```python
python_test(
    name = "foo_test",
    srcs = ["foo_test.py"],
    interpreter = "//third_party/python3/cpython:cpython_3.10|python",
)
```

results in 

```
bash: /tmp/plz_sandbox/foo_test.pex: /tmp/plz_sandbox/third_party/python3/cpython/usr/python3.10/bin/python3: bad interpreter: No such file or directory
```.

This change modifies `python_test` to check whether `interpreter` looks like a build label, and if so pass it to the final pex rule as `data`. I've tested that this fixes the issue by pulling in my forked plugin into the repo where i was seeing this issue and now the test runs successfully.