### PR TITLE
`pex_main`: always clean up exploded zip when exiting

### DIFF
--- a/tools/please_pex/pex/pex_main.py
+++ b/tools/please_pex/pex/pex_main.py
@@ -337,10 +337,12 @@ def explode_zip():
                 # that the cache has already been prepared.
                 lockfile.write("pex unzip completed")
         sys.path = [PEX_PATH] + [x for x in sys.path if x != PEX]
-        yield
-        if no_cache:
-            import shutil
-            shutil.rmtree(basepath)
+        try:
+            yield
+        finally:
+            if no_cache:
+                import shutil
+                shutil.rmtree(basepath)
 
     return _explode_zip
 


### PR DESCRIPTION
If a pex file contains zip-unsafe files or is otherwise told to explode itself when it runs (e.g. via the `PEX_EXPLODE` environment variable), `pex_main` extracts its own contents to a temporary directory. However, it only deletes those files after the entry point script finishes executing provided that the script does not throw an exception. For large pex archives, this can quickly fill up the file system containing the temporary directory.

Unconditionally delete the extracted contents of the pex when the entry point script finishes executing.

Fixes #131.