### PR TITLE
Add support to chained tag matching

### DIFF
--- a/tools/wheel_resolver/__init__.py
+++ b/tools/wheel_resolver/__init__.py
@@ -13,6 +13,7 @@ _LOGGER = logging.getLogger(__name__)
 
 click_log.basic_config(_LOGGER)
 
+
 @click.command()
 @click.option(
     "--url",

--- a/tools/wheel_resolver/wheel.py
+++ b/tools/wheel_resolver/wheel.py
@@ -1,6 +1,7 @@
 import typing
 import distlib.locators
 import logging
+import itertools
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -74,4 +75,16 @@ def _is_wheel(url: str) -> bool:
 
 
 def _is_compatible(url: str, tags: typing.List[str]) -> bool:
-    return any(t in url for t in tags)
+    url_tags = extract_wheel_tags(url)
+    return any(t in url_tags for t in tags)
+
+
+def extract_wheel_tags(url: str) -> list[str]:
+    _, _, interpreter, abi, platform = url.replace(".whl", "").split("/")[-1].split("-")
+    interpreters, abis, platforms = (
+        interpreter.split("."),
+        abi.split("."),
+        platform.split("."),
+    )
+    combinations = list(itertools.product(interpreters, abis, platforms))
+    return ["-".join(combo) for combo in combinations]

--- a/tools/wheel_resolver/wheel.py
+++ b/tools/wheel_resolver/wheel.py
@@ -80,11 +80,10 @@ def _is_compatible(url: str, tags: typing.List[str]) -> bool:
 
 
 def extract_wheel_tags(url: str) -> list[str]:
-    _, _, interpreter, abi, platform = url.replace(".whl", "").split("/")[-1].split("-")
-    interpreters, abis, platforms = (
-        interpreter.split("."),
-        abi.split("."),
-        platform.split("."),
-    )
+    _, _, interpreter, abi, platform = url.removesuffix(".whl").split("/")[-1].split("-")
+    interpreters = interpreter.split(".")
+    abis = abi.split(".")
+    platforms = platform.split(".")
+    
     combinations = list(itertools.product(interpreters, abis, platforms))
     return ["-".join(combo) for combo in combinations]

--- a/tools/wheel_resolver/wheel_test.py
+++ b/tools/wheel_resolver/wheel_test.py
@@ -127,6 +127,11 @@ class TestIsCompatible:
                 expected=True,
             ),
             IsCompatibleCase(
+                url="https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310.cp311-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                tags=["cp310-cp310-manylinux_2_17_x86_64"],
+                expected=True,
+            ),
+            IsCompatibleCase(
                 url="https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
                 tags=["cp311-cp311-manylinux_2_17_x86_64"],
                 expected=False,


### PR DESCRIPTION
**TLDR**: this PR adds support for "chained tags" where the URL specifies multiple tag values for each of the 3 tags (interpreter, abi or platform).

**Context**

There are 3 compatibility tags: interpreter, abi and platform ([see the Python Packaging User Guide on this](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#overview)).

PyPI packages specify the tags that they support. The Wheel Resolver compares these values against the tags provided by the user to the Wheel Resolver. This prevents the user from downloading packages that are incompatible with the system they're using.

**Problem**
`_is_compatible` matches a chained tag value (e.g. `py2.py3`) against the system's equivalent tag (e.g. `py3`) rather than treating it as 2 different values (i.e. `py2` and `py3`).

This prevents the Wheel Resolver from downloading wheels that use chained tag values.

**Proposed change**
Extend `_is_compatible` to create combinations of multiple potential tag values for a URL when it uses chained tag values. Each of these tag values would be compared against the system tags.

The new test shows how this works.