### PR TITLE
Fix functionality gaps of wheel resolver: support prereleases and all system tags

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -119,6 +119,11 @@ Optional = true
 Inherit = true
 Help = The tool used to resolve wheels with using the pypi API.
 
+[PluginConfig "prereleases"]
+DefaultValue = false
+Type = bool
+Help = Allow prereleased versions in python_wheel targets
+
 [PluginConfig "require_licences"]
 DefaultValue = false
 Type = bool

--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -586,7 +586,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
     if tool:
         # Try the URLs generated using the wheel name schemes. If those fail, try
         # generating a url with the wheel_resolver tool and download that if successful.
-        cmd = f'$TOOL --package {package_name} --version {version} --prereleases '
+        cmd = f'$TOOL --package {package_name} --version {version} --prereleases {prereleases}'
         if urls:
             cmd += ' --urls ' + ' '.join(['%s' % url for url in urls])
         file_rule = build_rule(

--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -508,7 +508,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
                  outs:list=None, post_install_commands:list=None, patch:str|list=None, licences:list=None,
                  test_only:bool&testonly=False, repo:str=None, zip_safe:bool=True, visibility:list=None,
                  deps:list=[], name_scheme:str=None, strip:list=['*.pyc', 'tests'], binary = False,
-                 entry_points={}, tool:str=CONFIG.PYTHON.WHEEL_TOOL):
+                 entry_points={}, tool:str=CONFIG.PYTHON.WHEEL_TOOL, prereleases:bool=CONFIG.PYTHON.PRERELEASES):
     """Downloads a Python wheel and extracts it.
 
     This is a lightweight pip-free alternative to pip_library which supports cross-compiling.
@@ -586,7 +586,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
     if tool:
         # Try the URLs generated using the wheel name schemes. If those fail, try
         # generating a url with the wheel_resolver tool and download that if successful.
-        cmd = f'$TOOL --package {package_name} --version {version}'
+        cmd = f'$TOOL --package {package_name} --version {version} --prereleases '
         if urls:
             cmd += ' --urls ' + ' '.join(['%s' % url for url in urls])
         file_rule = build_rule(

--- a/tools/wheel_resolver/__init__.py
+++ b/tools/wheel_resolver/__init__.py
@@ -97,6 +97,7 @@ def main(
 
     # We're currently hardcoding PyPI but we should consider allowing other
     # repositories
+    # TODO (tm-jdelapuente): allow downloads from other package repositories
     locator = distlib.locators.SimpleScrapingLocator(url="https://pypi.org/simple")
     locator.wheel_tags = list(itertools.product(interpreter, abi, platform))
     u = wheel.url(

--- a/tools/wheel_resolver/__init__.py
+++ b/tools/wheel_resolver/__init__.py
@@ -8,6 +8,7 @@ import tools.wheel_resolver.wheel as wheel
 import tools.wheel_resolver.output as output
 import packaging.tags as tags
 import distlib.locators
+import itertools
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,7 +48,7 @@ click_log.basic_config(_LOGGER)
 @click.option(
     "--platform",
     # Must cast to list so click knows we want multiple default values.
-    default=set(tags.platform_tags()),
+    default={t.platform for t in tags.sys_tags()},
     metavar="PLATFORM",
     multiple=True,
     help="The platform identifier, for example linux_x86_64 or linux_i686",
@@ -60,14 +61,23 @@ click_log.basic_config(_LOGGER)
     multiple=True,
     help="The ABI identifier, for example cp310 or abi3",
 )
+@click.option(
+    "--prereleases",
+    default=False,
+    metavar="PRERELEASES",
+    show_default=True,
+    multiple=False,
+    help="Whether prereleased wheels should also be downloaded",
+)
 @click_log.simple_verbosity_option(_LOGGER)
 def main(
     url: typing.List[str],
-    package_name: typing.Optional[str],
+    package_name: str,
     package_version: typing.Optional[str],
     interpreter: typing.Tuple[str, ...],
     platform: typing.Tuple[str, ...],
     abi: typing.Tuple[str, ...],
+    prereleases: bool = False,
 ):
     """Resolve a wheel by name and version to a URL.
 
@@ -85,6 +95,10 @@ def main(
             click.echo(u)
             return
 
+    # We're currently hardcoding PyPI but we should consider allowing other
+    # repositories
+    locator = distlib.locators.SimpleScrapingLocator(url="https://pypi.org/simple")
+    locator.wheel_tags = list(itertools.product(interpreter, abi, platform))
     u = wheel.url(
         package_name=package_name,
         package_version=package_version,
@@ -97,16 +111,9 @@ def main(
                 platforms=set(platform).union({"any"}),
             )
         ],
-        # We're currently hardcoding PyPI but we should consider allowing other
-        # repositories
-        locator=distlib.locators.SimpleScrapingLocator(url="https://pypi.org/simple"),
+        locator=locator,
+        prereleases=prereleases,
     )
-    response = requests.head(u)
-    if response.status_code != requests.codes.ok:
-        _LOGGER.error(
-            "%s-%s is not available, tried %r", package_name, package_version, u
-        )
-        sys.exit(1)
 
     if not output.try_download(u):
         _LOGGER.error("Could not download from %r", u)

--- a/tools/wheel_resolver/wheel_test.py
+++ b/tools/wheel_resolver/wheel_test.py
@@ -115,35 +115,3 @@ class TestUrl:
             tags=["cp310-cp310-manylinux_2_17_x86_64"],
             locator=self._mock_locator(download_urls={expected}),
         )
-
-
-class TestIsCompatible:
-    @pytest.mark.parametrize(
-        argnames=IsCompatibleCase._fields,
-        argvalues=[
-            IsCompatibleCase(
-                url="https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                tags=["cp310-cp310-manylinux_2_17_x86_64"],
-                expected=True,
-            ),
-            IsCompatibleCase(
-                url="https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310.cp311-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                tags=["cp310-cp310-manylinux_2_17_x86_64"],
-                expected=True,
-            ),
-            IsCompatibleCase(
-                url="https://files.pythonhosted.org/packages/29/61/bf33c6c85c55bc45a29eee3195848ff2d518d84735eb0e2d8cb42e0d285e/PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
-                tags=["cp311-cp311-manylinux_2_17_x86_64"],
-                expected=False,
-            ),
-        ],
-    )
-    def test_is_compatible(
-        self,
-        url: str,
-        tags: typing.List[str],
-        expected: bool,
-    ) -> None:
-        assert expected == sut._is_compatible(
-            url=url, tags=tags
-        ), f"{url!r} is not compatible with {tags!r}"


### PR DESCRIPTION
**Problems**

1. Prereleased wheels aren't being downloaded
2. Some packages aren't being downloaded because `distlib`'s function that creates tags is less complete than `packaging.tags.sys_tags`

**Solution**

1. Prereleased wheels are downloaded by passing `prereleases=True` to `locator.locate`
2. To use the more complete `packaging.tags.sys_tags` we create those tags and assign them to `locator.wheel_tags`

**UX change**

Since this is OSS it's ideal to give users the ability to stop prereleases from being used. This would give people that work with Please more control over what dependencies get included within their organization.

To do this, the wheel resolver now takes a flag `prereleases` that is set in `.plzconfig` under the new `PluginConfig` `"prereleases"`. 

**How I tested**
1. In my repo I have the target `build/plugins/BUILD` where I changed the `plugin_repo` for `python` to 

```BUILD
plugin_repo(
    name = "python",
    owner = "tm-jdelapuente",
    plugin = "python-rules",
    revision = "b6ee92cbb4a460d49622c961701a2b243a6e5c04",
)
```

2. Clone this repo locally and build the wheel resolver with `plz build tools/wheel_resolver:wheel_resolver`
3. In `.plzconfig` add under `[plugin "python"]` both the wheel resolver that takes the `prereleases` flag to the path of the built wheel resolver PEX and `prereleases = true`

Replace my `wheeltool` value for the path in your system
```BUILD
wheeltool = /home/jdelapuente/repos/python-rules/plz-out/bin/tools/wheel_resolver/wheel_resolver.pex
prereleases = true
```
4. Build Python wheels in my repo with `plz build third_party/python3:all`