### PR TITLE
View debug logs without having to shell via a verbosity variable in .plzconfig

### DIFF
--- a/.plzconfig
+++ b/.plzconfig
@@ -131,7 +131,7 @@ Inherit = true
 Help = If set, the licences field on pip_library and python_wheel will be mandatory
 
 [PluginConfig "verbosity"]
-DefaultVault = "info"
+DefaultValue = "info"
 Help = Passes verbosity level to wheel_tool, for example: wheel_tool --verbosity info
 Optional = true
 

--- a/.plzconfig
+++ b/.plzconfig
@@ -130,6 +130,10 @@ Type = bool
 Inherit = true
 Help = If set, the licences field on pip_library and python_wheel will be mandatory
 
+[PluginConfig "verbosity"]
+DefaultVault = "info"
+Help = Passes verbosity level to wheel_tool, for example: wheel_tool --verbosity info
+Optional = true
 
 [PluginConfig "feature_flags"]
 DefaultValue = ""

--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -508,7 +508,8 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
                  outs:list=None, post_install_commands:list=None, patch:str|list=None, licences:list=None,
                  test_only:bool&testonly=False, repo:str=None, zip_safe:bool=True, visibility:list=None,
                  deps:list=[], name_scheme:str=None, strip:list=['*.pyc', 'tests'], binary = False,
-                 entry_points={}, tool:str=CONFIG.PYTHON.WHEEL_TOOL, prereleases:bool=CONFIG.PYTHON.PRERELEASES):
+                 entry_points={}, tool:str=CONFIG.PYTHON.WHEEL_TOOL, prereleases:bool=CONFIG.PYTHON.PRERELEASES,
+                 tool_verbosity:str=CONFIG.PYTHON.VERBOSITY):
     """Downloads a Python wheel and extracts it.
 
     This is a lightweight pip-free alternative to pip_library which supports cross-compiling.
@@ -586,7 +587,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
     if tool:
         # Try the URLs generated using the wheel name schemes. If those fail, try
         # generating a url with the wheel_resolver tool and download that if successful.
-        cmd = f'$TOOL --package {package_name} --version {version} --prereleases {prereleases}'
+        cmd = f'$TOOL --package {package_name} --version {version} --prereleases {prereleases} --verbosity {tool_verbosity}'
         if urls:
             cmd += ' --urls ' + ' '.join(['%s' % url for url in urls])
         file_rule = build_rule(


### PR DESCRIPTION
**Problem**

Viewing debug logs in the Wheel Resolver requires going into `--shell` and manually passing `--verbosity`, which creates toil when debugging.

**Proposal**

Create a new Python Rules plugin to pass verbosity levels via `.plzconfig`. 

**Change in UX to get debug logs**

Today:
- You need to run the command with `--shell` (e.g. `plz build third_party/python3:_PyInquirer#download --shell`)
- Copy the bash command when you enter the container (e.g. `$TOOL --package {LIBRARY} --version {VERSION} --prereleases True` and paste it to the input starting with `$`
- Add `--verbosity debug` and then run it to get the logs

With this proposal:
- Change `verbosity` in `.plzconfig` to `debug`
- Run the build command (e.g. `plz build third_party/python3:_{LIBRARY}#download` 
- Change `verbosity` to `info` or another value once you want to leave debug mode

**Graceful error handling**

This proposal gracefully handles wrong values to `verbosity` and lists the valid values.

For example when setting in `.plzconfig` `verbosity = debg` the error message printed says

```
Error building target //third_party/python3:_{LIBRARY}#download: exit status 2
Usage: wheel_resolver.pex [OPTIONS]
Try 'wheel_resolver.pex --help' for help.

Error: Invalid value for '--verbosity' / '-v': Must be CRITICAL, ERROR, WARNING, INFO or DEBUG, not debg
```