### PR TITLE
Bug: change so that every URL is passed with its individual --urls flag in python_wheel

### DIFF
--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -588,7 +588,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
         # generating a url with the wheel_resolver tool and download that if successful.
         cmd = f'$TOOL --package {package_name} --version {version} --prereleases {prereleases}'
         if urls:
-            cmd += ' --urls ' + ' '.join(['%s' % url for url in urls])
+            cmd += ''.join([' --urls %s' % url for url in urls])
         file_rule = build_rule(
             name = name,
             tag = 'download',


### PR DESCRIPTION
**Problem**

The Wheel Resolver can take URLs where it tries to fetch wheels before requesting them from PyPI.

Right now the URLs are being passed as space-separated strings under a single `--urls` flag. The problem is that `click` needs each url passed to the binary to be prepended by `--url` or `--urls`, rather than all URLs being passed under a single flag.

The consequence is that if `python-rules` is configured with `wheelrepo` instead of the Wheel Resolver using its URLs to fetch wheels it will error instead  

**Solution**

I changed the `join` function invocation to prepend every URL with `--urls` to satisfy the `click` requirements.

**Testing**

I validated this change both in Please setups that:
- Uses a Wheel Resolver
- Does not use a Wheel Resolver and relies on the `python_wheel` using `wheelrepo` internally

The output had no errors, so this shouldn't break existing implementations of `python-rules`. 