### PR TITLE
Add missing licences to third party python dependencies

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -433,7 +433,7 @@ pip_library(
 pip_library(
     name = "setuptools",
     test_only = True,
-    licences = ["MIT"]
+    licences = ["MIT"],
     version = "47.1.1",
 )
 

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -18,12 +18,17 @@ package(
 
 python_wheel(
     name = "flatbuffers",
+    licences = ["Apache-2.0"],
     test_only = True,
     version = "2.0",
 )
 
 python_wheel(
     name = "astunparse",
+    licences = [
+        "BSD-3-Clause",
+        "PSF-2.0",
+    ],
     test_only = True,
     version = "1.6.3",
 )
@@ -31,6 +36,7 @@ python_wheel(
 python_wheel(
     name = "xmlrunner",
     package_name = "unittest_xml_reporting",
+    licences = ["LGPL-3.0-only"],
     version = "1.11.0",
     deps = [":six"],
 )
@@ -38,6 +44,7 @@ python_wheel(
 python_wheel(
     name = "six",
     outs = ["six.py"],
+    licences = ["MIT"],
     hashes = ["8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"],
     version = "1.14.0",
 )
@@ -48,6 +55,7 @@ python_wheel(
         "43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
     ],
     version = "2.23.0",
+    licences = ["Apache-2.0"],
     deps = [
         ":certifi",
         ":chardet",
@@ -58,6 +66,7 @@ python_wheel(
 
 python_wheel(
     name = "certifi",
+    licences = ["MPL-2.0"],
     hashes = ["017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3"],
     version = "2019.11.28",
 )
@@ -65,24 +74,28 @@ python_wheel(
 python_wheel(
     name = "chardet",
     hashes = ["fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"],
+    licences = ["LGPL-2.1-only"],
     version = "3.0.4",
 )
 
 python_wheel(
     name = "idna",
     hashes = ["a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"],
+    licences = ["BSD-3-Clause"],
     version = "2.9",
 )
 
 python_wheel(
     name = "urllib3",
     hashes = ["2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc"],
+    licences = ["MIT"],
     version = "1.25.8",
 )
 
 python_wheel(
     name = "colorlog",
     hashes = ["732c191ebbe9a353ec160d043d02c64ddef9028de8caae4cfa8bd49b6afed53e"],
+    licences = ["MIT"],
     version = "4.1.0",
 )
 
@@ -91,6 +104,7 @@ python_wheel(
     package_name = "python_dateutil",
     hashes = ["961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"],
     test_only = True,  # Not used by plz itself.
+    licences = ["BSD-3-Clause"],
     version = "2.8.2",
     deps = [":six"],
 )
@@ -98,6 +112,7 @@ python_wheel(
 python_wheel(
     name = "protobuf",
     outs = ["google"],
+    licences = ["BSD-3-Clause"],
     version = "3.19.4",
     deps = [":six"],
 )
@@ -138,12 +153,14 @@ else:
 python_multiversion_wheel(
     name = "coverage",
     urls = _coverage_urls,
+    licences = ["Apache-2.0"],
     version = _coverage_version,
 )
 
 python_wheel(
     name = "pluggy",
     hashes = ["d89c696a773f8bd377d18e5ecda92b7a3793cbe66c87060a6fb58c7b6e1061f7"],
+    licences = ["MIT"],
     version = "1.3.0",
 )
 
@@ -157,11 +174,16 @@ python_wheel(
 python_wheel(
     name = "packaging",
     hashes = [],
+    licences = [
+        "Apache-2.0",
+        "BSD-2-Clause",
+    ],
     version = "24.1",
 )
 
 pip_library(
     name = "wheel_filename",
+    licences = ["MIT"],
     version = "1.3.0",
 )
 
@@ -173,6 +195,7 @@ python_wheel(
     ],
     entry_points = "pytest:main",
     hashes = ["1d881c6124e08ff0a1bb75ba3ec0bfd8b5354a01c194ddd5a0a870a48d99b002"],
+    licences = ["MIT"],
     version = "7.4.2",
     deps = [
         ":colorama",
@@ -191,11 +214,16 @@ python_wheel(
 python_wheel(
     name = "exceptiongroup",
     hashes = ["343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"],
+    licences = [
+        "MIT",
+        "PSF-2.0",
+    ],
     version = "1.1.3",
 )
 
 python_wheel(
     name = "iniconfig",
+    licences = ["MIT"],
     version = "1.1.1",
 )
 
@@ -209,6 +237,7 @@ python_wheel(
         "behave_test": "setuptools_behave:behave_test",
     },
     hashes = ["ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c"],
+    licences = ["BSD-2-Clause"],
     version = "1.2.6",
     deps = [
         ":colorama",
@@ -227,12 +256,14 @@ python_wheel(
         "parse.py",
     ],
     hashes = ["2bb9c56c65bf609abbbef372bdcdd7b9c163745e7daf5e8217dba50a55850510"],
+    licences = ["MIT"],
     version = "1.15.0",
 )
 
 python_wheel(
     name = "parse_type",
     hashes = ["089a471b06327103865dfec2dd844230c3c658a4a1b5b4c8b6c16c8f77577f9e"],
+    licences = ["MIT"],
     version = "0.5.2",
 )
 
@@ -246,6 +277,7 @@ python_wheel(
 python_wheel(
     name = "win_unicode_console",
     hashes = ["7a7fb8bf98bcacb328d1f607065c0f89107c7e8f4b02caf12e5f02fb462512a6"],
+    licences = ["MIT"],
     version = "0.5",
 )
 
@@ -253,12 +285,14 @@ python_wheel(
     name = "enum34",
     outs = ["enum"],
     hashes = ["708aabfb3d5898f99674c390d360d59efdd08547019763622365f19e84a7fef4"],
+    licences = ["BSD-3-Clause"],
     version = "1.1.9",
 )
 
 python_wheel(
     name = "colorama",
     hashes = ["7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"],
+    licences = ["BSD-3-Clause"],
     version = "0.4.3",
 )
 
@@ -266,6 +300,7 @@ python_wheel(
     name = "absl",
     package_name = "absl_py",
     hashes = ["c106f6ef0ae86c1273b0858b40ee15b99fad1c223838387b9d11446a033bbcb1"],
+    licences = ["Apache-2.0"],
     version = "0.9.0",
     deps = [":six"],
 )
@@ -273,12 +308,14 @@ python_wheel(
 python_wheel(
     name = "portalocker",
     hashes = ["874d6063c6ceb185fe4771da41b01872d2c56d292db746698f8ad7bf1833c905"],
+    licences = ["BSD-3-Clause"],
     version = "1.7.0",
 )
 
 pip_library(
     name = "numpy",
     test_only = True,
+    licences = ["BSD-3-Clause"],
     version = "1.23.4",
     zip_safe = False,
 )
@@ -286,6 +323,7 @@ pip_library(
 pip_library(
     name = "keras_applications",
     test_only = True,
+    licences = ["MIT"],
     version = "1.0.8",
     deps = [
         ":h5py",
@@ -295,6 +333,7 @@ pip_library(
 pip_library(
     name = "opt_einsum",
     test_only = True,
+    licences = ["MIT"],
     version = "3.2.1",
     deps = [
         ":numpy",
@@ -304,6 +343,7 @@ pip_library(
 pip_library(
     name = "keras_preprocessing",
     test_only = True,
+    licences = ["MIT"],
     version = "1.1.0",
     deps = [
         ":numpy",
@@ -314,6 +354,7 @@ pip_library(
 pip_library(
     name = "grpcio",
     test_only = True,
+    licences = ["Apache-2.0"],
     version = "1.49.1",
     deps = [
         ":six",
@@ -323,6 +364,7 @@ pip_library(
 pip_library(
     name = "google-pasta",
     test_only = True,
+    licences = ["Apache-2.0"],
     version = "0.2.0",
     deps = [
         ":six",
@@ -332,30 +374,35 @@ pip_library(
 pip_library(
     name = "gast",
     test_only = True,
+    licences = ["BSD-3-Clause"],
     version = "0.2.2",
 )
 
 pip_library(
     name = "astor",
     test_only = True,
+    licences = ["BSD-3-Clause"],
     version = "0.8.1",
 )
 
 pip_library(
     name = "termcolor",
     test_only = True,
+    licences = ["MIT"],
     version = "1.1.0",
 )
 
 pip_library(
     name = "wrapt",
     test_only = True,
+    licences = ["BSD-2-Clause"],
     version = "1.12.1",
 )
 
 pip_library(
     name = "h5py",
     test_only = True,
+    licences = ["BSD-3-Clause"],
     version = "3.7.0",
     deps = [
         ":numpy",
@@ -366,12 +413,14 @@ pip_library(
 pip_library(
     name = "pytz",
     test_only = True,
+    licences = ["MIT"],
     version = "2018.4",
 )
 
 pip_library(
     name = "pandas",
     test_only = True,
+    licences = ["BSD-3-Clause"],
     version = "1.5.0",
     deps = [
         ":dateutil",
@@ -384,12 +433,14 @@ pip_library(
 pip_library(
     name = "setuptools",
     test_only = True,
+    licences = ["MIT"]
     version = "47.1.1",
 )
 
 pip_library(
     name = "scipy",
     test_only = True,
+    licences = ["BSD-3-Clause"],
     version = "1.9.2",
     zip_safe = False,
     deps = [
@@ -402,6 +453,7 @@ pip_library(
     name = "googleapis_common_protos",
     package_name = "googleapis-common-protos",
     test_only = True,
+    licences = ["Apache-2.0"],
     version = "1.52.0",
     deps = [
         ":protobuf_pip",
@@ -412,6 +464,7 @@ pip_library(
     name = "protobuf_pip",
     package_name = "protobuf",
     test_only = True,
+    licences = ["BSD-3-Clause"],
     version = "3.12.2",
     deps = [
         ":setuptools",
@@ -421,17 +474,20 @@ pip_library(
 
 pip_library(
     name = "progress",
+    licences = ["ISC"],
     version = "1.5",
 )
 
 pip_library(
     name = "cx_oracle",
     package_name = "cx-Oracle",
+    licences = ["BSD-3-Clause"],
     version = "8.2.1",
 )
 
 pip_library(
     name = "argparse",
+    licences = ["PSF-2.0"],
     version = "1.4.0",
 )
 
@@ -452,6 +508,7 @@ python_wheel(
     name = "typing_extensions",
     outs = ["typing_extensions.py"],
     hashes = ["sha256: 16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"],
+    licences = ["PSF-2.0"],
     version = "4.4.0",
 )
 
@@ -459,12 +516,14 @@ python_wheel(
     name = "mypy_extensions",
     outs = ["mypy_extensions.py"],
     hashes = ["sha256: 090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"],
+    licences = ["MIT"],
     version = "0.4.3",
 )
 
 python_wheel(
     name = "tomli",
     hashes = ["sha256: 939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"],
+    licences = ["MIT"],
     version = "2.0.1",
 )
 
@@ -472,6 +531,7 @@ python_wheel(
     name = "mypy",
     binary = True,
     hashes = ["sha256: 1021c241e8b6e1ca5a47e4d52601274ac078a89845cfde66c6d5f769819ffa1d"],
+    licences = ["MIT"],
     version = "0.982",
     deps = [
         ":mypy_extensions",
@@ -517,6 +577,7 @@ filegroup(
 python_wheel(
     name = "click",
     hashes = [],
+    licences = ["BSD-3-Clause"],
     version = "8.1.7",
     deps = [],
 )
@@ -526,6 +587,7 @@ python_wheel(
     package_name = "click_log",
     outs = ["click_log"],
     hashes = [],
+    licences = ["MIT"],
     name_scheme = "{url_base}/ae/5a/4f025bc751087833686892e17e7564828e409c43b632878afeae554870cd/{package_name}-{version}-py2.py3-none-any.whl",
     repo = "https://files.pythonhosted.org/packages",
     version = "0.4.0",


### PR DESCRIPTION
This took a fair bit more work than the golang one (#155 ), but I've gone through the source repositories of each of these dependencies and filled in which licence they each have