### PR TITLE
Include wheel_resolver in tools release

### DIFF
--- a/package/BUILD
+++ b/package/BUILD
@@ -2,6 +2,7 @@ subinclude("//tools:version", "//build_defs:archs", "///go//build_defs:go")
 
 release_files = {
     "please_pex": "//tools/please_pex",
+    "wheel_resolver": "//tools/wheel_resolver",
 }
 
 def release_file(name:str, file_target:str, arch:str):


### PR DESCRIPTION
The wheel resolver tool was supposed to be included in [the tools-v1.3.0 release](https://github.com/please-build/python-rules/releases/tag/tools-v1.3.0), and #149 , but it wasn't actually included because it wasn't listed in `//package:release_files`

This PR adds it to that list