### PR TITLE
Refactor wheel_resolver to allow for non-PyPI downloads

### DIFF
--- a/tools/wheel_resolver/BUILD
+++ b/tools/wheel_resolver/BUILD
@@ -1,22 +1,22 @@
 subinclude("//build_defs:python")
 
 python_binary(
-    name = "wheel_resolver",
-    main = "main.py",
-    visibility = ["PUBLIC"],
-    deps = [
+    name="wheel_resolver",
+    main="main.py",
+    visibility=["PUBLIC"],
+    deps=[
         ":wheel",
     ],
 )
 
 python_library(
-    name = "wheel",
-    srcs = [
+    name="wheel",
+    srcs=[
         "__init__.py",
         "wheel.py",
         "output.py",
     ],
-    deps = [
+    deps=[
         "//third_party/python:click",
         "//third_party/python:click-log",
         "//third_party/python:distlib",
@@ -26,14 +26,14 @@ python_library(
 )
 
 python_test(
-    name = "test",
-    timeout = 600,
-    srcs = [
+    name="test",
+    timeout=600,
+    srcs=[
         "__init___test.py",
         "wheel_test.py",
     ],
-    test_runner = "pytest",
-    deps = [
+    test_runner="pytest",
+    deps=[
         ":wheel",
         "//third_party/python:pytest",
     ],

--- a/tools/wheel_resolver/__init__.py
+++ b/tools/wheel_resolver/__init__.py
@@ -85,12 +85,12 @@ def main(
 
     """
     try:
-        download_output = output.get()
+        output_name = output.get()
     except output.OutputNotSetError:
         _LOGGER.error("could not get $OUTS")
         sys.exit(1)
 
-    if output.download(package_name, package_version, url, download_output):
+    if output.download(package_name, package_version, url, output_name):
         return
 
     locator = distlib.locators.SimpleScrapingLocator(url="https://pypi.org/simple")
@@ -114,10 +114,9 @@ def main(
         pypi_url = (u,)
     except Exception as error:
         _LOGGER.error(error)
-        _LOGGER.error(
-            "could not find PyPI URL for %s-%s", package_name, package_version
-        )
+        _LOGGER.error(f"could not find PyPI URL for {package_name}-{package_version}")
         sys.exit(1)
 
-    if not output.download(package_name, package_version, pypi_url, download_output):
+    if not output.download(package_name, package_version, pypi_url, output_name):
         _LOGGER.error("could not download %s-%s", package_name, package_version)
+        sys.exit(1)

--- a/tools/wheel_resolver/__init___test.py
+++ b/tools/wheel_resolver/__init___test.py
@@ -1,8 +1,5 @@
 import click.testing
-import pytest
 import unittest.mock
-import requests
-
 import tools.wheel_resolver as sut
 
 
@@ -12,15 +9,7 @@ class TestMain:
         result = runner.invoke(cli=sut.main, args=["--help"])
         assert result.exit_code == 0
 
-    @unittest.mock.patch.object(sut.output, "try_download")
-    @unittest.mock.patch.object(sut.requests, "head")
-    def test_any_in_platforms(
-            self, _mock_requests_head: unittest.mock.MagicMock, _mock_try_download: unittest.mock.MagicMock
-    ) -> None:
-        _mock_try_download.return_value = True
-        _mock_requests_head.return_value = requests.Response()
-        _mock_requests_head.return_value.status_code = requests.codes.ok
-
+    def test_any_in_platforms(self) -> None:
         runner = click.testing.CliRunner()
         with unittest.mock.patch.object(sut.wheel, "url") as mock_url:
             result = runner.invoke(
@@ -38,4 +27,60 @@ class TestMain:
                 # Due to tags being a required keyword argument
                 if "tags" in kwargs:
                     assert any([t for t in kwargs["tags"] if t.endswith("any")])
-        assert result.exit_code == 0
+
+    @unittest.mock.patch.object(sut, "_LOGGER")
+    @unittest.mock.patch.object(sut.output, "get")
+    def test_output_not_set_error(
+        self,
+        mock_output_get: unittest.mock.MagicMock,
+        mock_logger: unittest.mock.MagicMock,
+    ) -> None:
+        mock_output_get.side_effect = sut.output.OutputNotSetError
+
+        runner = click.testing.CliRunner()
+        result = runner.invoke(cli=sut.main, args=["--package-name", "some-package"])
+
+        mock_logger.error.assert_called_once_with("could not get $OUTS")
+        assert result.exit_code == 1
+
+    @unittest.mock.patch.object(sut.output, "get")
+    @unittest.mock.patch.object(sut.output, "download")
+    @unittest.mock.patch.object(sut.wheel, "url")
+    @unittest.mock.patch.object(sut, "_LOGGER")
+    def test_wheel_url_error(
+        self,
+        mock_logger: unittest.mock.MagicMock,
+        mock_wheel_url: unittest.mock.MagicMock,
+        mock_output_download: unittest.mock.MagicMock,
+        mock_output_get: unittest.mock.MagicMock,
+    ) -> None:
+
+        # Setup variables
+        package_name = "test-package"
+        package_version = "1.0.0"
+        exception_message = "Test Exception"
+
+        # Set up mocks
+        mock_output_get.return_value = "output_name"
+        mock_output_download.return_value = False
+        mock_wheel_url.side_effect = Exception(exception_message)
+
+        # Run the command
+        runner = click.testing.CliRunner()
+        result = runner.invoke(
+            cli=sut.main,
+            args=[
+                "--package-name",
+                f"{package_name}",
+                "--package-version",
+                f"{package_version}",
+            ],
+        )
+
+        # Check that the error was logged correctly
+        mock_logger.error.assert_any_call(
+            f"could not find PyPI URL for {package_name}-{package_version}",
+        )
+
+        # Check that the program exited with an error code
+        assert result.exit_code == 1

--- a/tools/wheel_resolver/output.py
+++ b/tools/wheel_resolver/output.py
@@ -18,16 +18,20 @@ def get() -> str:
 
 
 def download(
-    package_name: str, package_version: str, url: typing.List[str], download_output: str
-) -> typing.Optional[str]:
+    package_name: str,
+    package_version: typing.Optional[str],
+    url: typing.Tuple[str],
+    download_output: str,
+) -> bool:
     """Download url to $OUTS."""
     for u in url:
         try:
             urllib.request.urlretrieve(u, download_output)
-        except urllib.error.HTTPError:
+        except urllib.error.HTTPError as error:
             _LOGGER.warning(
-                "%s-%s is not available in %s", package_name, package_version, u
+                f"download {package_name}-{package_version} from {u}: {error}",
             )
         else:
-            return u
-    return None
+            _LOGGER.info(f"downloaded {package_name}-{package_version} from {u}")
+            return True
+    return False

--- a/tools/wheel_resolver/output.py
+++ b/tools/wheel_resolver/output.py
@@ -1,27 +1,33 @@
 import os
-import sys
 import urllib.request
 import logging
+import typing
 
 _LOGGER = logging.getLogger(__name__)
+
 
 class OutputNotSetError(RuntimeError):
     pass
 
-def try_download(url):
-    """
-    Try to download url to $OUTS. Returns false if
-    it failed.
-    """
+
+def get() -> str:
     output = os.environ.get("OUTS")
     if output is None:
         raise OutputNotSetError()
-
-    try:
-        urllib.request.urlretrieve(url, output)
-    except urllib.error.HTTPError:
-        return False
-
-    return True
+    return output
 
 
+def download(
+    package_name: str, package_version: str, url: typing.List[str], download_output: str
+) -> typing.Optional[str]:
+    """Download url to $OUTS."""
+    for u in url:
+        try:
+            urllib.request.urlretrieve(u, download_output)
+        except urllib.error.HTTPError:
+            _LOGGER.warning(
+                "%s-%s is not available in %s", package_name, package_version, u
+            )
+        else:
+            return u
+    return None

--- a/tools/wheel_resolver/wheel.py
+++ b/tools/wheel_resolver/wheel.py
@@ -1,7 +1,6 @@
 import typing
 import distlib.locators
 import logging
-import itertools
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
A pending problem ([see this comment](https://github.com/please-build/python-rules/pull/152#discussion_r1703983200)) was to allow downloads outside PyPI.

This PR refactors wheel_resolver to allow that. 

**Core logic**

1, Try to download from the links passed to `--urls` first
2. If it doesn't download the package, check if PyPI has a URL for that package
3. If there is a URL, use it to try to download from there

**Testing**
I've covered all the exit points of `main`.