### PR TITLE
Load distribution metadata for unimported modules in meta path finder

### DIFF
--- a/tools/please_pex/pex/pex_main.py
+++ b/tools/please_pex/pex/pex_main.py
@@ -250,10 +250,9 @@ class ModuleDirImport(MetaPathFinder):
                         if name and self._match_file(name, ""):
                             return True
 
-        if context.name in sys.modules:
-            distribution = PexDistribution(context.name)
-            if distribution._has_distribution():
-                yield distribution
+        distribution = PexDistribution(context.name)
+        if distribution._has_distribution():
+            yield distribution
 
     def get_code(self, fullname):
         module = self.load_module(fullname)


### PR DESCRIPTION
`PexDistribution` is only used to locate distribution metadata for modules that already exist in `sys.modules`, requiring a module to be imported by the interpreter before its distribution metadata can be queried. Remove this restriction, allowing distribution metadata to be queried at any time provided the module exists in the pex file.

Fixes #177.