### PR TITLE
Remove Python < 3.8 compatibility from pex bootstrap code

### DIFF
--- a/test/python_coverage_test.py
+++ b/test/python_coverage_test.py
@@ -21,8 +21,6 @@ class PythonCoverageTest(unittest.TestCase):
         import coverage
         self.assertIsNotNone(coverage)
 
-    @unittest.skipIf(sys.version_info.major < 3,
-                     'Not working on python2 as python2 does not support multi-version-wheels')
     def test_can_import_tracer(self):
         """Test we can import the binary tracer module."""
         from coverage import tracer


### PR DESCRIPTION
Python >= 3.8 has been required by python-rules for some time, and older versions have long been out of support upstream - simplify some of the bootstrap code by removing shims for old Python versions.