### PR TITLE
Run CI tests against in-repo pex tool

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -2,15 +2,19 @@ name: Python rules
 on: [push, pull_request]
 jobs:
   test:
+    name: Test (Python ${{ matrix.python-version }}, ${{ matrix.pex-tool }} pex tool)
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        include:
-          - python-version: '3.8'
-          - python-version: '3.9'
-          - python-version: '3.10'
-          - python-version: '3.11'
-          - python-version: '3.12'
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+        pex-tool:
+          - default
+          - in-repo
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -20,6 +24,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set profile
         run: export PLZ_CONFIG_PROFILE=ci && echo $PATH
+      - name: Build and use in-repo pex tool
+        if: matrix.pex-tool == 'in-repo'
+        run: |
+          ./pleasew build //tools/please_pex
+          cp $(./pleasew query outputs //tools/please_pex) $HOME/please_pex
+          echo "PLZ_ARGS=-o plugin.python.pextool:$HOME/please_pex" >> $GITHUB_ENV
       - name: Run tests
         run: ./pleasew test --log_file plz-out/log/test.log -e e2e
       - name: Run e2e test
@@ -28,7 +38,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs-${{ matrix.python-version }}
+          name: logs-${{ matrix.python-version }}-please_pex-${{ matrix.pex-tool }}
           path: plz-out/log
   release:
     needs: [test]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+tools/please_pex_dev
+
 # Entries below this point are managed by Please (DO NOT EDIT)
 plz-out
 .plzconfig.local

--- a/.plzconfig.tool_dev
+++ b/.plzconfig.tool_dev
@@ -1,0 +1,10 @@
+; This configuration uses the in-repo versions of the Python tools, rather than the released
+; versions that are downloaded from GitHub Releases in //tools.
+;
+; To use this configuration:
+; 1) Run `plz build //tools/please_pex`
+; 2) Copy plz-out/bin/tools/please_pex/please_pex to tools/please_pex_dev
+; 3) Run `plz --profile=tool_dev [...]`
+
+[Plugin "python"]
+PexTool = //tools:please_pex_dev

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -17,3 +17,19 @@ remote_file(
     binary = True,
     visibility = ["PUBLIC"],
 )
+
+# This target is only intended for use during plugin development. Its only purpose is to break the
+# mutual dependency between please_pex and the python_wheels in the bootstrap pex, which prevents
+# PexTool from being set to //tools/please_pex in order to test changes to please_pex.
+#
+# To test changes to please_pex:
+# 1) Run `plz build //tools/please_pex`
+# 2) Copy plz-out/bin/tools/please_pex/please_pex to tools/please_pex_dev
+# 3) Run `plz -o plugin.python.pextool://tools:please_pex_dev [...]`
+filegroup(
+    name = "please_pex_dev",
+    srcs = ["please_pex_dev"],
+    binary = True,
+    labels = ["manual"],
+    visibility = ["PUBLIC"],
+)

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -22,10 +22,7 @@ remote_file(
 # mutual dependency between please_pex and the python_wheels in the bootstrap pex, which prevents
 # PexTool from being set to //tools/please_pex in order to test changes to please_pex.
 #
-# To test changes to please_pex:
-# 1) Run `plz build //tools/please_pex`
-# 2) Copy plz-out/bin/tools/please_pex/please_pex to tools/please_pex_dev
-# 3) Run `plz -o plugin.python.pextool://tools:please_pex_dev [...]`
+# See .plzconfig.tool_test for more details.
 filegroup(
     name = "please_pex_dev",
     srcs = ["please_pex_dev"],


### PR DESCRIPTION
The CI tests currently only run against the released version of please_pex defined in `TOOLS_VERSION` in `tools/BUILD`, which means that changes made in please_pex PRs aren't actually tested in CI until a new tools release has already been cut and the version number bumped in `TOOLS_VERSION`. Add a new dimension to the GHA matrix that builds the in-repo version of please_pex and overrides the value of `PexTool` in the plugin config so that tests are run against it too.