### PR TITLE
Add pex meta path finder tests

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -196,3 +196,11 @@ python_test(
         "//third_party/python:click-log",
     ],
 )
+
+python_test(
+    name = "distribution_metadata_test",
+    srcs = ["distribution_metadata_test.py"],
+    deps = [
+        "//third_party/python:pygments",
+    ],
+)

--- a/test/distribution_metadata_test.py
+++ b/test/distribution_metadata_test.py
@@ -1,0 +1,14 @@
+from importlib.metadata import PackagePath, files, version
+import unittest
+
+
+class DistributionMetadataTest(unittest.TestCase):
+    """Tests that the pex meta path finder in ModuleDirImport is able to extract distribution
+    metadata directly from a .dist-info directory inside the pex file.
+    """
+
+    def test_importlib_metadata_version(self):
+        self.assertEqual(version("pygments"), "2.18.0")
+
+    def test_importlib_metadata_files(self):
+        self.assertIn(PackagePath("pygments/__init__.py"), files("pygments"))

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -574,6 +574,27 @@ filegroup(
     ],
 )
 
+# Note: this is used by //test:distribution_metadata_test as an example of a module that contains
+# distribution metadata. The importlib.metadata API should be able to identify the version of the
+# module from the contents of its .dist-info directory. The choice of module isn't that important,
+# and is fairly arbitrary - it just happens to be widely-used, written in pure Python, and has no
+# dependencies.
+
+python_wheel(
+    name = "pygments",
+    outs = [
+        "pygments",
+        "pygments-2.18.0.dist-info",
+    ],
+    hashes = ["b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"],
+    licences = ["BSD-2-Clause"],
+    test_only = True,
+    version = "2.18.0",
+    visibility = [
+        "//test:distribution_metadata_test",
+    ],
+)
+
 # Note: this package is used for //test:name_scheme_test as an example of something using a list of
 # name schemes
 python_wheel(


### PR DESCRIPTION
These check that the pex meta path finder in the `ModuleDirImport` class can correctly extract distribution metadata from a `.dist-info` directory inside a pex file via the `importlib.metadata` API.