### PR TITLE
CI: use interpreter provided by `actions/setup-python`

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -24,9 +24,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Use this Python in Please build environments
         run: |
-          echo "$PATH"
           echo "CI_PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
-          echo "PLZ_ARGS=-o build.passenv:PATH -o build.passenv:CI_PYTHON_VERSION" >> $GITHUB_ENV
+          echo "PLZ_ARGS=-o plugin.python.defaultinterpreter:$(which python3) -o build.passenv:CI_PYTHON_VERSION" >> $GITHUB_ENV
       - name: Build and use in-repo pex tool
         if: matrix.pex-tool == 'in-repo'
         run: |

--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -18,22 +18,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup python
-        uses: actions/setup-python@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Set profile
-        run: export PLZ_CONFIG_PROFILE=ci && echo $PATH
+      - name: Use this Python in Please build environments
+        run: |
+          echo "$PATH"
+          echo "CI_PYTHON_VERSION=${{ matrix.python-version }}" >> $GITHUB_ENV
+          echo "PLZ_ARGS=-o build.passenv:PATH -o build.passenv:CI_PYTHON_VERSION" >> $GITHUB_ENV
       - name: Build and use in-repo pex tool
         if: matrix.pex-tool == 'in-repo'
         run: |
           ./pleasew build //tools/please_pex
           cp $(./pleasew query outputs //tools/please_pex) $HOME/please_pex
-          echo "PLZ_ARGS=-o plugin.python.pextool:$HOME/please_pex" >> $GITHUB_ENV
+          echo "PLZ_ARGS="$(grep ^PLZ_ARGS= $GITHUB_ENV | cut -d= -f2-)" -o plugin.python.pextool:$HOME/please_pex" >> $GITHUB_ENV
       - name: Run tests
         run: ./pleasew test --log_file plz-out/log/test.log -e e2e
       - name: Run e2e test
-        run: ./pleasew test --profile ci --log_file plz-out/log/e2e.log -i e2e
+        run: ./pleasew test --log_file plz-out/log/e2e.log -i e2e
       - name: Archive logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -5,6 +5,7 @@ jobs:
     name: Test (Python ${{ matrix.python-version }}, ${{ matrix.pex-tool }} pex tool)
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - '3.9'

--- a/test/BUILD
+++ b/test/BUILD
@@ -204,3 +204,9 @@ python_test(
         "//third_party/python:pygments",
     ],
 )
+
+# This test need only run in the GitHub Actions workflow - it is skipped outside this environment.
+python_test(
+    name = "ci_test",
+    srcs = ["ci_test.py"],
+)

--- a/test/ci_test.py
+++ b/test/ci_test.py
@@ -1,0 +1,17 @@
+"""Contains tests specific to the CI environment provided by GitHub Actions workflows."""
+
+import os
+import sys
+import unittest
+
+
+@unittest.skipIf(os.getenv("CI_PYTHON_VERSION") is None, "Not running in CI environment")
+class CITest(unittest.TestCase):
+
+    def test_use_setup_python_interpreter(self):
+        """Ensures that python_tests are being run by the Python interpreter installed by
+        actions/setup-python.
+        """
+        ci_major, _, ci_minor = os.getenv("CI_PYTHON_VERSION").partition(".")
+        self.assertEqual(int(ci_major), sys.version_info[0])
+        self.assertEqual(int(ci_minor), sys.version_info[1])


### PR DESCRIPTION
`actions/setup-python` "installs" a non-standard Python interpreter in the CI environment by adding a directory containing it to `PATH`, but the updated `PATH` isn't inherited by the Please build sandbox, so the system-wide Python interpreter is always used. Pass through the value of `PATH` to the sandbox so that the correct `actions/setup-python` interpreter is used.

Fixes #127.