### PR TITLE
Upgrade NumPy to 2.1.3

### DIFF
--- a/test/expected_labels_on_numpy.txt
+++ b/test/expected_labels_on_numpy.txt
@@ -1,3 +1,3 @@
 py
-pip:numpy==1.23.4
+pip:numpy==2.1.3
 py:zip-unsafe

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -316,7 +316,7 @@ pip_library(
     name = "numpy",
     test_only = True,
     licences = ["BSD-3-Clause"],
-    version = "1.23.4",
+    version = "2.1.3",
     zip_safe = False,
 )
 


### PR DESCRIPTION
NumPy 1.23.4's installation process has a dependency on distutils, which was removed from the standard library in Python 3.12.