### PR TITLE
Use `assertEqual` instead of `assertEquals`

### DIFF
--- a/test/coverage_output_test.py
+++ b/test/coverage_output_test.py
@@ -9,4 +9,4 @@ class CoverageOutputTest(unittest.TestCase):
 
     def test_stuff(self):
         """Test that the flux capacitor is correctly calibrated."""
-        self.assertEquals(2, 2)
+        self.assertEqual(2, 2)


### PR DESCRIPTION
`assertEquals` was a deprecated alias of `assertEqual` in `unittest`, but has been removed as of Python 3.12.