### PR TITLE
Remove unnecessary xmlrunner dependency on six

### DIFF
--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -36,9 +36,8 @@ python_wheel(
 python_wheel(
     name = "xmlrunner",
     package_name = "unittest_xml_reporting",
-    licences = ["BSD"],
+    licences = ["BSD-2-Clause"],
     version = "3.2.0",
-    deps = [":six"],
 )
 
 python_wheel(

--- a/tools/please_pex/pex/pex.go
+++ b/tools/please_pex/pex/pex.go
@@ -126,7 +126,6 @@ func (pw *Writer) SetTest(srcs []string, testRunner string, addTestRunnerDeps bo
 		// These are the outputs of //third_party/python:unittest_bootstrap and its transitive dependencies
 		// (except for those from //third_party/python:test_bootstrap).
 		testRunnerDeps = append(testRunnerDeps,
-			".bootstrap/six.py",
 			".bootstrap/xmlrunner",
 		)
 		pw.testRunner = filepath.Join(testRunnersDir, "unittest.py")


### PR DESCRIPTION
xmlrunner doesn't depend on six any more - remove it as a dependency of the xmlrunner `python_wheel` and also remove it as a transitive dependency of the unittest test runner pex.