### PR TITLE
Implement missing `locate_file` method in pex meta path finder

### DIFF
--- a/tools/please_pex/pex/pex_main.py
+++ b/tools/please_pex/pex/pex_main.py
@@ -155,6 +155,9 @@ class PexDistribution(Distribution):
             if name and self._match_file(name, filename):
                 return zf.read(name).decode(encoding="utf-8")
 
+    def locate_file(self, path):
+        raise RuntimeError("This distribution has no real file system")
+
     read_text.__doc__ = Distribution.read_text.__doc__
 
 


### PR DESCRIPTION
This is an abstract method of `importlib.metadata.Distribution` that must be implemented in Python >= 3.12 to avoid `DeprecationWarning`s. It doesn't actually make sense for `locate_file` to return anything in a `PexDistribution`, given that the files it finds exist in a zip file rather than on a real file system.