### PR TITLE
Use actions/checkout v4 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -24,7 +24,7 @@ jobs:
             pex-tool: default
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This silences some noisy warnings about `node12` being deprecated.