### PR TITLE
Upgrade grpcio to 1.67.1

### DIFF
--- a/test/expected_labels_on_grpcio.txt
+++ b/test/expected_labels_on_grpcio.txt
@@ -1,2 +1,2 @@
 py
-pip:grpcio==1.49.1
+pip:grpcio==1.67.1

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -348,10 +348,7 @@ pip_library(
     name = "grpcio",
     test_only = True,
     licences = ["Apache-2.0"],
-    version = "1.49.1",
-    deps = [
-        ":six",
-    ],
+    version = "1.67.1",
 )
 
 pip_library(


### PR DESCRIPTION
grpcio 1.49.1 claims to be compatible with Python >= 3.7 but uses CPython API bits that were removed in Python 3.12. Upgrade to 1.67.1, which explicitly supports all Python versions between 3.8 and 3.13. This version also drops the dependency on six.