### PR TITLE
Optimise PexDistribution a bit

### DIFF
--- a/tools/please_pex/pex/pex_main.py
+++ b/tools/please_pex/pex/pex_main.py
@@ -138,15 +138,13 @@ class PexDistribution(Distribution):
         self._name = name
         self._pex_file = pex_file
         self._prefix = prefix
+        self._re = re.compile(r"{path}(?:-.*)?\.(?:dist|egg)-info/(.*)".format(
+            path=os.path.join(self._prefix, self._name) if self._prefix else self._name,
+        ))
 
     def _match_file(self, name, filename):
-        if re.match(
-            r"{path}(?:-.*)?\.(?:dist|egg)-info/{filename}".format(
-                path=os.path.join(self._prefix, self._name) if self._prefix else self._name,
-                filename=filename,
-            ),
-            name,
-        ):
+        match = self._re.match(name)
+        if match and match.group(1) == filename:
             return name
 
     def read_text(self, filename):


### PR DESCRIPTION
Doing a bit of a perf pass, seeing some slow tests (especially now we have debug builds of Python which are quite a bit slower overall).

Only compile the regex (and do `os.path.join` which is slower than you'd think) once. 

I have a test case (`time plz cover --shell=run <redacted>`) which is reduced from 1m47s to 1m28s