### PR TITLE
Remove getsitepackages() implementation

### DIFF
--- a/tools/please_pex/pex/pex_main.py
+++ b/tools/please_pex/pex/pex_main.py
@@ -5,6 +5,7 @@ from importlib import import_module, machinery
 from importlib.abc import MetaPathFinder
 from importlib.metadata import Distribution
 from importlib.util import spec_from_loader
+from site import getsitepackages
 import itertools
 import os
 import re
@@ -12,38 +13,6 @@ import runpy
 import sys
 import tempfile
 import zipfile
-
-
-try:
-    from site import getsitepackages
-except:
-    def getsitepackages(prefixes=[sys.prefix, sys.exec_prefix]):
-        """Returns a list containing all global site-packages directories.
-
-        For each directory present in ``prefixes`` (or the global ``PREFIXES``),
-        this function will find its `site-packages` subdirectory depending on the
-        system environment, and will return a list of full paths.
-        """
-        sitepackages = []
-        seen = set()
-
-        if prefixes is None:
-            prefixes = PREFIXES
-
-        for prefix in prefixes:
-            if not prefix or prefix in seen:
-                continue
-            seen.add(prefix)
-
-            if os.sep == '/':
-                sitepackages.append(os.path.join(prefix, "lib",
-                                            "python%d.%d" % sys.version_info[:2],
-                                            "site-packages"))
-            else:
-                sitepackages.append(prefix)
-                sitepackages.append(os.path.join(prefix, "lib", "site-packages"))
-
-        return sitepackages
 
 # Put this pex on the path before anything else.
 PEX = os.path.abspath(sys.argv[0])


### PR DESCRIPTION
From [the docs](https://docs.python.org/3/library/site.html#site.getsitepackages) this was added in 3.2 so we shouldn't have to worry about it not being there any more.