### PR TITLE
Suppress filename output from licences

### DIFF
--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -620,7 +620,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
         cmd += ['find . %s | xargs rm -rf' % ' -or '.join(['-name "%s"' % s for s in strip])]
     if not licences:
         cmd += ['find . -name METADATA -or -name PKG-INFO | grep -v "^./build/" | '
-                'xargs grep -E "License ?:" | grep -v UNKNOWN | cat || true']
+                'xargs grep -hE "License ?:" | grep -v UNKNOWN | cat || true']
     if patch:
         patches, c = _patch_cmd(patch)
         cmd += c


### PR DESCRIPTION
We have a case where we're getting warnings about not having a licence on a wheel. I think it should have one and it looks like the build output has things like
```
./xmlsec-1.3.14.dist-info/METADATA:License: MIT
./xmlsec-1.3.14.dist-info/METADATA:Classifier: License :: OSI Approved :: MIT License
```
whereas locally I get
```
License: MIT
Classifier: License :: OSI Approved :: MIT License
```
I don't know why this difference happens in this case, but adding the `-h` flag should tell grep never to emit those filenames.