### PR TITLE
Delete some non-functional python 2 compat code from test runner

### DIFF
--- a/tools/please_pex/pex/test_runners/unittest.py
+++ b/tools/please_pex/pex/test_runners/unittest.py
@@ -52,10 +52,7 @@ def import_tests():
             yield import_module(pkg_name)
         except ImportError:
             with open(filename, 'r') as f:
-                if PY_VERSION.major < 3:
-                    mod = imp.load_module(pkg_name, f, filename, ('.py', 'r', imp.PY_SOURCE))
-                else:
-                    mod = machinery.SourceFileLoader(pkg_name, filename).load_module()
+                mod = machinery.SourceFileLoader(pkg_name, filename).load_module()
 
                 # Have to set the attribute on the parent module too otherwise some things
                 # can't find it.


### PR DESCRIPTION
`PY_VERSION` isn't defined so this doesn't work. Am getting rid of just the python 2 branch because of Chesterton's fence, but I think we could argue for deleting the whole lot since this was clearly not getting hit on successful paths before