### PR TITLE
Add python_toolchain

### DIFF
--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -796,3 +796,75 @@ if CONFIG.BAZEL_COMPATIBILITY:
     py_library = python_library
     py_binary = python_binary
     py_test = python_test
+
+
+def python_toolchain(name:str, version:str, release:str, arch:str=None,
+                     vendor:str=None, os:str=None, build:str=None,
+                     hashes:list=None, visibility:list=None):
+    """Defines download of a CPython interpreter for use within the repo.
+
+    These are taken from https://github.com/indygreg/python-build-standalone; see
+    https://gregoryszorc.com/docs/python-build-standalone/main/running.html for more info
+    about the various os/arch/build options available.
+    At minimum the Python version and release datestamp must be specified; other fields
+    will attempt to autodetect based on the _host_ architecture. It may be useful to specify
+    these in some cases where we aren't able to select the name they would use.
+
+    Args:
+      name: Name of the target
+      version: Python version to download, e.g. "3.10.16"
+      release: Release datestamp, e.g. "20241206"
+      arch: Architecture to download for, e.g. "aarch64" or "x86_64".
+      vendor: Vendor to target, e.g. "unknown" (for linux) or "apple" (for macos).
+      os: OS to target, e.g. "linux" or "darwin".
+      build: The build type, one of "debug", "noopt", "lto", "pgo" or "pgo+lto".
+             By default will choose debug for dbg / cover builds and pgo+lto otherwise.
+      hashes: List of hashes that the downloaded tarball must match.
+      visibility: Visibility of the toolchain.
+    """
+    # TODO(peterebden): The URLs are going to change in like two days, once that happens
+    #                   we should update to point to appropriate new locations.
+    if not arch:
+        if CONFIG.HOSTARCH == "amd64":
+            arch = "x86_64_v2"
+        elif CONFIG.HOSTARCH == "arm64":
+            arch = "aarch64"
+        else:
+            fail(f"Unsure what arch to use for {CONFIG.HOSTARCH}, please specify")
+    if not vendor:
+        if CONFIG.HOSTOS == "linux":
+            vendor = "unknown"
+        elif CONFIG.HOSTOS == "darwin":
+            vendor = "apple"
+        elif CONFIG.HOSTOS == "windows":
+            vendor = "windows"
+        else:
+            fail(f"Unsure what vendor to use for {CONFIG.HOSTOS}, please specify")
+    if not os:
+        if CONFIG.HOSTOS == "linux":
+            os = "linux-gnu"
+        elif CONFIG.HOSTOS == "darwin":
+            os = "darwin"
+        elif CONFIG.HOSTOS == "windows":
+            os = "msvc"
+        else:
+            fail(f"Unsure what OS to use for {CONFIG.HOSTOS}, please specify")
+    if not build:
+        build = "debug" if (CONFIG.BUILD_CONFIG == "dbg" or CONFIG.BUILD_CONFIG == "cover") else "pgo+lto"
+
+    download = remote_file(
+        name = f"_{name}#download",
+        url = f"https://github.com/indygreg/python-build-standalone/releases/download/{release}/cpython-{version}+{release}-{arch}-{vendor}-{os}-{build}-full.tar.zst",
+        hashes = hashes,
+    )
+    return build_rule(
+        name = name,
+        srcs = [download],
+        outs = [f"python-{version}"],  # We might want this to be more specific so you could mix multiple in a directory?
+        cmd = "tar --strip-components=1 -xf $SRCS && mv install $OUTS",
+        binary = True,
+        entry_points = {
+            "python": f"python-{version}/bin/python3",
+        },
+        visibility = visibility,
+    )

--- a/third_party/cpython/BUILD
+++ b/third_party/cpython/BUILD
@@ -1,23 +1,12 @@
-version = "3.12.7"
-release = "20241016"
+subinclude("//build_defs:python")
 
-remote_file(
-    name = "download",
-    url = f"https://github.com/indygreg/python-build-standalone/releases/download/{release}/cpython-{version}+{release}-x86_64_v2-unknown-linux-gnu-pgo+lto-full.tar.zst",
-    hashes = ["98f64550d63fa2f5468b28482b1fed8aef33a70d81f1549b7a8be1a59db41d98"],
-)
-
-genrule(
+python_toolchain(
     name = "cpython",
-    srcs = [":download"],
-    outs = [f"python-{version}"],
-    cmd = [
-        "tar --strip-components=1 -xf $SRCS",
-        "mv install $OUTS",
+    version = "3.12.7",
+    release = "20241016",
+    hashes = [
+        "0f089b56633c90757bd7027ea2548f024dd187a08c1702d8bd76ff9c507723b4",  # linux dbg
+        "98f64550d63fa2f5468b28482b1fed8aef33a70d81f1549b7a8be1a59db41d98",  # linux opt
     ],
-    binary = True,
-    entry_points = {
-        "python": f"python-{version}/bin/python3",
-    },
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
We have `go_toolchain` and `java_toolchain`, let Python get in on the fun too.

This uses python-build-standalone which I hear is going to move in a couple of days (but I assume old URLs will continue to redirect, and we can update easily once that happens.
It doesn't seem particularly hard apart from matching up how we name os's / architectures etc to how they do it. Can be extended easily enough in future if someone needs a different one.