### PR TITLE
feat: support overriding module-dir

### DIFF
--- a/build_defs/python.build_defs
+++ b/build_defs/python.build_defs
@@ -94,7 +94,8 @@ def python_library(name:str, srcs:list=[], resources:list=[], deps:list=[], visi
 def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=None, deps:list=[],
                   data:list=None, visibility:list=None, test_only:bool=False, zip_safe:bool=None,
                   site:bool=False, strip:bool=False, interpreter:str=CONFIG.PYTHON.DEFAULT_INTERPRETER,
-                  shebang:str=CONFIG.PYTHON.DEFAULT_SHEBANG, labels:list&features&tags=[]):
+                  shebang:str=CONFIG.PYTHON.DEFAULT_SHEBANG, module_dir:str=CONFIG.PYTHON.MODULE_DIR,
+                  labels:list&features&tags=[]):
     """Generates a Python binary target.
 
     This compiles all source files together into a single .pex file which can
@@ -127,6 +128,8 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
       shebang (str): Exact shebang to apply to the generated file. Defaults to the value
                      of the python.defaultshebang setting, if not set we will
                      determine something appropriate for the given interpreter.
+      module_dir (str): The path to the third party python directory in python import path format.
+                     Defaults to value of python.moduledir setting.
       labels (list): Labels to apply to this rule.
     """
     assert main not in srcs, "main file should not be included in srcs"
@@ -145,7 +148,7 @@ def python_binary(name:str, main:str, srcs:list=[], resources:list=[], out:str=N
     shebang = shebang or _interpreter_cmd(interpreter)
     zipsafe_flag = '' if zip_safe is False else '--zip_safe'
     cmd = '$TOOLS_PEX -s "%s" -m "%s" %s --interpreter_options="%s"' % (
-        shebang, CONFIG.PYTHON.MODULE_DIR, zipsafe_flag, CONFIG.PYTHON.INTERPRETER_OPTIONS)
+        shebang, module_dir, zipsafe_flag, CONFIG.PYTHON.INTERPRETER_OPTIONS)
 
     # If content hashing feature flag is enabled, we use the hash of the built
     # dependencies instead of the RULE_HASH as the base of the pex extraction
@@ -219,7 +222,8 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
                 labels:list&features&tags=[], size:str=None, flags:str='', visibility:list=None,
                 sandbox:bool=None, timeout:int=0, flaky:bool|int=0, env:dict=None,
                 test_outputs:list=None, zip_safe:bool=None, interpreter:str=CONFIG.PYTHON.DEFAULT_INTERPRETER,
-                site:bool=False, test_runner:str=None, shebang:str=CONFIG.PYTHON.DEFAULT_SHEBANG):
+                site:bool=False, test_runner:str=None, shebang:str=CONFIG.PYTHON.DEFAULT_SHEBANG,
+                module_dir:str=CONFIG.PYTHON.MODULE_DIR):
     """Generates a Python test target.
 
     This works very similarly to python_binary; it is also a single .pex file
@@ -257,6 +261,8 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
       shebang (str): Exact shebang to apply to the generated file. Defaults to the value
                      of the python.defaultshebang setting, if not set we will
                      determine something appropriate for the given interpreter.
+      module_dir (str): The path to the third party python directory in python import path format.
+                     Defaults to value of python.moduledir setting.
       site (bool): Allows the Python interpreter to import site; conversely if False, it will be
                    started with the -S flag to avoid importing site.
       test_runner (str): Specify which Python test runner to use for these tests. One of
@@ -264,7 +270,7 @@ def python_test(name:str, srcs:list, data:list|dict=[], resources:list=[], deps:
     """
     test_runner = test_runner or CONFIG.PYTHON.TEST_RUNNER
     shebang = shebang or _interpreter_cmd(interpreter)
-    cmd = f'$TOOLS_PEX -t -s "{shebang}" -m "{CONFIG.PYTHON.MODULE_DIR}" -r "{test_runner}" --zip_safe --add_test_runner_deps --interpreter_options="{CONFIG.PYTHON.INTERPRETER_OPTIONS}" --stamp="$RULE_HASH"'
+    cmd = f'$TOOLS_PEX -t -s "{shebang}" -m "{module_dir}" -r "{test_runner}" --zip_safe --add_test_runner_deps --interpreter_options="{CONFIG.PYTHON.INTERPRETER_OPTIONS}" --stamp="$RULE_HASH"'
     if site:
         cmd += ' -S'
 
@@ -517,7 +523,8 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
                  deps:list=[], name_scheme:str|list=CONFIG.PYTHON.WHEEL_NAME_SCHEME,
                  strip:list=['*.pyc', 'tests'], binary = False, entry_points:dict|str={},
                  tool:str=CONFIG.PYTHON.WHEEL_TOOL, prereleases:bool=CONFIG.PYTHON.PRERELEASES,
-                 tool_verbosity:str=CONFIG.PYTHON.VERBOSITY, interpreter:str=CONFIG.PYTHON.DEFAULT_INTERPRETER):
+                 tool_verbosity:str=CONFIG.PYTHON.VERBOSITY, interpreter:str=CONFIG.PYTHON.DEFAULT_INTERPRETER,
+                 module_dir:str=CONFIG.PYTHON.MODULE_DIR):
     """Downloads a Python wheel and extracts it.
 
     This is a lightweight pip-free alternative to pip_library which supports cross-compiling.
@@ -561,6 +568,8 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
                                This parameter can be a string, in which case the rule can be ran directly, or a
                                dictionary, for example `{"protoc", "protoc.__main__:main"}. For the latter, each key can
                                be ran using annotated labels, e.g. `plz run //third_party/python:protobuf|protoc`
+      module_dir (str): The path to the third party python directory in python import path format.
+                     Defaults to value of python.moduledir setting.
       tool (str): Tool to locate python wheel file in an index
     """
     binary = binary or entry_points
@@ -689,6 +698,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
                 lib_rule = lib_rule,
                 visibility = visibility,
                 test_only = test_only,
+                module_dir = module_dir,
             )
 
         entry_point_binaries = [_wheel_entrypoint_binary(
@@ -698,6 +708,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
             visibility = visibility,
             test_only = test_only,
             out = f"{alias}.pex",
+            module_dir = module_dir,
         ) for alias, ep in entry_points.items()]
 
         return filegroup(
@@ -713,7 +724,7 @@ def python_wheel(name:str, version:str, labels:list=[], hashes:list=None, packag
         )
     return lib_rule
 
-def _wheel_entrypoint_binary(name:str, entrypoint:str, lib_rule, visibility, test_only, out=None):
+def _wheel_entrypoint_binary(name:str, entrypoint:str, lib_rule, visibility, test_only, module_dir:str, out=None):
     module, _, func = entrypoint.rpartition(":")
     main = text_file(
         name = tag(name, "main"),
@@ -727,6 +738,7 @@ def _wheel_entrypoint_binary(name:str, entrypoint:str, lib_rule, visibility, tes
         out = out,
         deps = [lib_rule],
         test_only = test_only,
+        module_dir = module_dir,
         visibility = visibility,
     )
 


### PR DESCRIPTION
:wave: We'd like to be able to add tools available on PyPi and manage their dependencies separately from the rest of our codebase (e.g. [semgrep](https://pypi.org/project/semgrep/) depends on a few modules that we use in the codebase but are incompatibly versioned).

At the moment, it appears we're constrained by the `ModuleDir` parameter to this plugin where we can only have one repository-wide directory for Python modules. 

This PR makes this configurable per `python_binary`, `python_test` and `python_wheel` which enables us to do things like this:

```
# third_party/python/pipdeptree/BUILD
# The below command works to run `pipdeptree`.
# $ plz run //third_party/python/pipdeptree:pipdeptree

python_wheel(
    name = "pipdeptree",
    version = "2.26.1",
    module_dir = "third_party.python.pipdeptree",
    hashes = ["3849d62a2ed641256afac3058c4f9b85ac4a47e9d8c991ee17a8f3d230c5cffb"],
    binary = True,
    deps = [":packaging", ":pip"],
    licences = ["MIT"],
)

python_wheel(
    name = "packaging",
    hashes = ["5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"],
    licences = [
        "Apache-2.0",
        "BSD-2-Clause",
    ],
    version = "24.1",
)

python_wheel(
    name = "pip",
    hashes = ["a775837439bf5da2c1a0c2fa43d5744854497c689ddbd9344cf3ea6d00598540"],
    licences = ["MIT"],
    version = "24.1",
)
```