### PR TITLE
Build please_pex releases in native environments

### DIFF
--- a/.github/workflows/please_pex_build.yaml
+++ b/.github/workflows/please_pex_build.yaml
@@ -1,0 +1,61 @@
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: "The platform on which this workflow should run. Must be one of darwin_amd64, darwin_arm64, freebsd_amd64, linux_amd64 or linux_arm64."
+        required: true
+        type: string
+jobs:
+  build:
+    name: ${{ inputs.platform }}
+    runs-on: ${{ (inputs.platform == 'freebsd_amd64' || startsWith(inputs.platform, 'linux_')) && 'ubuntu-24.04' || (inputs.platform == 'darwin_amd64' && 'macos-15-intel' || (inputs.platform == 'darwin_arm64' && 'macos-15' || 'unknown')) }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+      - name: Set up QEMU
+        if: ${{ startsWith(inputs.platform, 'linux_') }}
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker
+        if: ${{ startsWith(inputs.platform, 'linux_') }}
+        uses: docker/setup-docker-action@v4
+        with:
+          daemon-config: |
+            {
+              "debug": true,
+              "features": {
+                "containerd-snapshotter": true
+              }
+            }
+      - name: Build please_pex binary (on freebsd-builder image)
+        if: ${{ inputs.platform == 'freebsd_amd64' }}
+        uses: cross-platform-actions/action@v0.30.0
+        with:
+          operating_system: freebsd
+          architecture: x86-64
+          version: '14.3'
+          image_url: https://github.com/please-build/freebsd-builder/releases/download/v0.12.0-please.3/freebsd-14.3-x86-64.qcow2
+          shell: bash
+          shutdown_vm: true
+          run: package/gha_release.sh //package:please_pex_${{ inputs.platform }}
+      - name: Build please_pex binary (in alpine-builder container)
+        if: ${{ startsWith(inputs.platform, 'linux_') }}
+        run: |
+          docker run --rm \
+            --platform ${{ inputs.platform == 'linux_amd64' && 'linux/amd64' || 'linux/arm64' }} \
+            -v "/home/runner/work:/home/runner/work" \
+            --env "GITHUB_ACTIONS=$GITHUB_ACTIONS" \
+            --env "GITHUB_ENV=$GITHUB_ENV" \
+            --workdir "$GITHUB_WORKSPACE" \
+            ghcr.io/please-build/alpine-builder:v3.22-please.3 \
+            /bin/bash package/gha_release.sh //package:please_pex_${{ inputs.platform }}
+      - name: Build please_pex binary (on host)
+        if: ${{ startsWith(inputs.platform, 'darwin_') }}
+        run: package/gha_release.sh //package:please_pex_${{ inputs.platform }}
+      - name: Upload please_pex binary to artifact storage
+        uses: actions/upload-artifact@v5
+        with:
+          name: please_pex_${{ inputs.platform }}
+          path: ${{ env.ARTIFACT_PATH }}
+          if-no-files-found: error
+          compression-level: 9
+          retention-days: 1

--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -28,7 +28,7 @@ jobs:
           - '3.13'
           - '3.14'
   test-please_pex:
-    name: Test (${{ matrix.platform}}, Python ${{ matrix.python }}, in-repo please_pex)
+    name: Test please_pex
     uses: ./.github/workflows/plugin_test.yaml
     with:
       platform: ${{ matrix.platform }}
@@ -71,23 +71,46 @@ jobs:
           - '3.12'
           - '3.13'
           - '3.14'
+  build-please_pex-artifacts:
+    name: Build please_pex release artifacts
+    if: github.ref == 'refs/heads/master'
+    needs:
+      - test-please_pex
+    uses: ./.github/workflows/please_pex_build.yaml
+    with:
+      platform: ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - darwin_amd64
+          - darwin_arm64
+          - freebsd_amd64
+          - linux_amd64
+          - linux_arm64
   release-please_pex:
     name: Release please_pex
     if: github.ref == 'refs/heads/master'
     needs:
-      - test-please_pex
+      - build-please_pex-artifacts
     runs-on: ubuntu-latest
+    env:
+      BIN_DIR: /tmp/please_pex_release
     steps:
+      - name: Download please_pex binaries from artifact storage
+        uses: actions/download-artifact@v6
+        with:
+          path: ${{ env.BIN_DIR }}
+          pattern: please_pex_*
+          merge-multiple: true
       - name: Check out code
-        uses: actions/checkout@v5
-      - name: Build release files
-        run: ./pleasew build //package:please_pex_release_files
+        uses: actions/checkout@v6
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: thought-machine/release-action@master
         with:
-          release-files: plz-out/package/please_pex
+          release-files: ${{ env.BIN_DIR }}
           version-file: tools/please_pex/VERSION
           change-log-file: tools/please_pex/ChangeLog
           release-prefix: please_pex

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -24,7 +24,7 @@ on:
         default: //...
 jobs:
   test:
-    name: Run tests
+    name: ${{ inputs.platform }}, Python ${{ inputs.python }}
     runs-on: ${{ (inputs.platform == 'freebsd_amd64' || inputs.platform == 'linux_amd64') && 'ubuntu-24.04' || (inputs.platform == 'linux_arm64' && 'ubuntu-24.04-arm' || (inputs.platform == 'darwin_amd64' && 'macos-15-intel' || (inputs.platform == 'darwin_arm64' && 'macos-15' || 'unknown'))) }}
     steps:
       - name: Install Python in CI environment

--- a/package/gha_release.sh
+++ b/package/gha_release.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# This script builds a tool release (i.e. an architecture-specific binary target
+# in //tools) and reports its location to the actions/upload-artifact action so
+# it can be uploaded as part of the release workflow.
+
+if [ "$GITHUB_ACTIONS" != true ]; then
+    echo "This script should only be executed on GitHub Actions runners." >&2
+    exit 1
+fi
+
+target="$1"
+
+./pleasew -v notice -p build "$target"
+echo ARTIFACT_PATH="$(./pleasew query output $target)" >> $GITHUB_ENV


### PR DESCRIPTION
Now that please_pex writes a preamble C binary that is native to each platform supported by Please, please_pex is no longer just a Go binary that can be cross-compiled for every platform on a Linux amd64 runner: the preamble needs to be built natively for each platform and embedded in the please_pex binary for that platform.

Reorganise the please_pex test, build and release workflow so that the release binaries are built natively on their respective platforms: [alpine-builder](https://github.com/please-build/alpine-builder) for Linux (linking statically to musl results in a nice ~94KB binary), [freebsd-builder](https://github.com/please-build/freebsd-builder) for FreeBSD, and GitHub Actions' macOS 15 runners for Darwin.

Although Ubuntu arm64 GitHub runners are available, the linux_arm64 release has to be built on an Ubuntu amd64 runner because JavaScript-based workflow actions currently can't be executed on an Alpine arm64 container running on an arm64 host - see:

- https://github.com/actions/upload-artifact/issues/739
- https://github.com/actions/runner/issues/801