### PR TITLE
Search `PATH` when .pex is invoked at a relative path with no `/`

### DIFF
--- a/tools/please_pex/preamble/path.c
+++ b/tools/please_pex/preamble/path.c
@@ -1,4 +1,6 @@
 #include <libgen.h>
+#include <paths.h>
+#include <unistd.h>
 
 #if defined(__APPLE__)
 #include <mach-o/dyld.h>
@@ -13,7 +15,136 @@
 #include "util.h"
 
 /*
- * get_pex_path stores the canonical absolute path to the .pex file in pex_dir. It returns NULL on
+ * get_path_var stores the value of the PATH variable in path. It returns NULL on success and an
+ * error on failure.
+ *
+ * The value of the PATH variable is taken to be the first non-empty value in the following list:
+ * - The value of the PATH environment variable.
+ * - The value of the C standard library's _CS_PATH configuration variable.
+ * - The value of the C standard library's hardcoded default PATH variable.
+ */
+static err_t *get_path_var(char **path) {
+    char *path_env = getenv("PATH");
+    size_t len = 0;
+    err_t *err = NULL;
+
+    (*path) = NULL;
+
+    if (path_env != NULL) {
+        if (((*path) = strdup(path_env)) == NULL) {
+            err = err_from_errno("strdup path_env");
+        }
+        goto end;
+    }
+
+    if ((len = confstr(_CS_PATH, NULL, 0)) != 0) {
+        MALLOC(*path, char, len);
+        if (confstr(_CS_PATH, *path, len) == 0) {
+            err = err_from_errno("confstr write");
+        }
+        goto end;
+    }
+
+    MALLOC(*path, char, strlen(_PATH_DEFPATH) + 1); // 1 extra byte for trailing null
+    strcpy(*path, _PATH_DEFPATH);
+
+end:
+    if (err != NULL) {
+        FREE(*path);
+    }
+
+    return err;
+}
+
+/*
+ * resolve_path resolves the given path and stores the resolved path in res_path. It returns NULL on
+ * success and an error on failure.
+ *
+ * The given path is resolved as follows:
+ * - If the path contains a "/" character, resolve_path returns a copy of the given path.
+ * - If the path does not contain a "/" character, resolve_path treats it as a file name, and
+ *   searches directories in the PATH variable from left to right for a file with that name,
+ *   similarly to how a shell would. It returns the path to the first file it finds, which is
+ *   relative if the current directory is present in PATH and the file was found in the current
+ *   directory, or absolute otherwise.
+ */
+err_t *resolve_path(char *path, char **res_path) {
+    char *path_dirs = NULL;
+    char *dir_start = NULL;
+    char *dir_end = NULL;
+    size_t path_len = strlen(path);
+    size_t dir_len = 0;
+    err_t *err = NULL;
+
+    (*res_path) = NULL;
+
+    if (path_len == 0) {
+        err = err_from_str("empty path name given");
+        goto end;
+    }
+
+    // If the given path is a relative path containing a "/" or an absolute path, we don't need to
+    // do any PATH searching - just return a copy of the path we were given.
+    if (strchr(path, '/') != NULL) {
+        if (((*res_path) = strdup(path)) == NULL) {
+            err = err_from_errno("strdup path");
+        }
+        goto end;
+    }
+
+    if ((err = get_path_var(&path_dirs)) != NULL) {
+        err = err_wrap("get PATH variable", err);
+        goto end;
+    }
+
+    // Iterate over the directories in PATH:
+    dir_end = path_dirs;
+    do {
+        // Point dir_end to the end of the next directory in PATH.
+        for (dir_start = dir_end; *dir_end != 0 && *dir_end != ':'; dir_end++) {
+            continue;
+        }
+
+        // Construct a candidate path by concatenating the next directory in PATH and the file name
+        // we were given.
+        if (dir_start == dir_end) {
+            if (((*res_path) = strdup(path)) == NULL) {
+                err = err_from_errno("strdup path");
+                goto end;
+            }
+        } else {
+            dir_len = dir_end - dir_start;
+            MALLOC(*res_path, char, dir_len + 1 + path_len + 1); // 2 extra bytes for "/" separator and trailing null
+            strncpy(*res_path, dir_start, dir_len);
+            (*res_path)[dir_len] = '/';
+            strcpy((*res_path) + dir_len + 1, path);
+            (*res_path)[dir_len + 1 + path_len] = 0;
+        }
+
+        // If a file exists at this candidate path, stop searching PATH and return this path. We
+        // don't check whether it is executable, only whether it exists - this replicates the
+        // behaviour of (some) shells when they search PATH.
+        if (access(*res_path, F_OK) == 0) {
+            goto end;
+        }
+
+        FREE(*res_path);
+    } while (*dir_end++ == ':');
+
+    err = err_wrap("file not found in PATH", err_from_str(path));
+
+end:
+    FREE(path_dirs);
+
+    if (err != NULL) {
+        FREE(*res_path);
+    }
+
+    return err;
+}
+
+/*
+ * get_pex_path stores the canonical absolute path to the .pex file in pex_path. It returns NULL on
  * success and an error on failure.
  */
 err_t *get_pex_path(char **pex_path) {

--- a/tools/please_pex/preamble/path.c
+++ b/tools/please_pex/preamble/path.c
@@ -106,7 +106,9 @@ err_t *resolve_path(char *path, char **res_path) {
         }
 
         // Construct a candidate path by concatenating the next directory in PATH and the file name
-        // we were given.
+        // we were given. Shells treat a zero-length directory name in PATH as shorthand for the
+        // current working directory, in which case there's no need for any concatenation - the
+        // candidate path can just be the (relative) file name we were given.
         if (dir_start == dir_end) {
             if (((*res_path) = strdup(path)) == NULL) {
                 err = err_from_errno("strdup path");

--- a/tools/please_pex/preamble/path.h
+++ b/tools/please_pex/preamble/path.h
@@ -4,6 +4,7 @@
 
 #include "pexerror.h"
 
+err_t *resolve_path(char *path, char **res_path);
 err_t *get_pex_path(char **pex_path);
 err_t *get_plz_bin_path(char **path);
 

--- a/tools/please_pex/preamble/preamble.c
+++ b/tools/please_pex/preamble/preamble.c
@@ -306,6 +306,7 @@ end:
 int main(int argc, char **argv) {
     err_t *err = NULL;
     char *pex_path = NULL;
+    char *argv0_path = NULL;
     const cJSON *config = NULL;
     int config_args_len = 0;
     strlist_t *config_args = NULL;
@@ -323,7 +324,7 @@ int main(int argc, char **argv) {
     }
 
     if ((err = get_pex_path(&pex_path)) != NULL) {
-        log_fatal("Failed to resolve path to .pex file: %s", err_str(err));
+        log_fatal("Failed to get real path to .pex file: %s", err_str(err));
         return 1;
     }
 
@@ -366,9 +367,14 @@ int main(int argc, char **argv) {
         i++;
     }
     // - the name of the currently-executing program (which is also the .pex file that the
-    //   Python interpreter needs to execute) and the command line arguments given to this
-    //   process (if any);
-    for (i = 0; i < argc; i++) {
+    //   Python interpreter needs to execute);
+    if ((err = resolve_path(argv[0], &argv0_path)) != NULL) {
+        log_fatal("Failed to resolve path to .pex file: %s", err_str(err));
+        return 1;
+    }
+    interp_argv[1 + config_args_len] = argv0_path;
+    // - the remaining command line arguments given to this process (if any);
+    for (i = 1; i < argc; i++) {
         interp_argv[1 + config_args_len + i] = argv[i];
     }
     // - NULL (the terminator for execvp()).


### PR DESCRIPTION
In the preamble, mimic a shell's `PATH` searching behaviour when determining the path to the .pex file if it was invoked via a relative path name containing no `/` characters.

Assuming the output of a hypothetical `python_binary` with the run-time interpreter search path `python3` has been copied to `/usr/bin/out.pex`, this will cause the Python interpreter to be invoked using the arguments on the right-hand side when the .pex file is invoked using the argument on the left-hand side:

- `/abs/path/out.pex` -> `python3 /abs/path/out.pex`
- `rel/path/out.pex` -> `python3 rel/path/out.pex`
- `out.pex` -> `python3 /usr/bin/out.pex`

Fixes #298.