### PR TITLE
GHA: upgrade actions that use Node.js v20

### DIFF
--- a/.github/workflows/please_pex_build.yaml
+++ b/.github/workflows/please_pex_build.yaml
@@ -52,7 +52,7 @@ jobs:
         if: ${{ startsWith(inputs.platform, 'darwin_') }}
         run: package/gha_release.sh //package:please_pex_${{ inputs.platform }}
       - name: Upload please_pex binary to artifact storage
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: please_pex_${{ inputs.platform }}
           path: ${{ env.ARTIFACT_PATH }}

--- a/.github/workflows/plugin.yaml
+++ b/.github/workflows/plugin.yaml
@@ -98,7 +98,7 @@ jobs:
       BIN_DIR: /tmp/please_pex_release
     steps:
       - name: Download please_pex binaries from artifact storage
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           path: ${{ env.BIN_DIR }}
           pattern: please_pex_*

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "*** Running tests using in-repo Python interpreter: $_in_repo_interpreter"
           ./pleasew -o "plugin.python.defaultinterpreter:$_in_repo_interpreter" test --rerun --keep_going --log_file plz-out/log/test-in_repo_interpreter.log ${{ inputs.test_targets }}
       - name: Archive logs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs-${{ inputs.id }}-${{ inputs.platform }}-python_${{ inputs.python }}-please_pex_${{ inputs.please_pex_from_repo && 'repo' || 'stable' }}
           path: plz-out/log


### PR DESCRIPTION
Node.js v20 is going away on GitHub-hosted runners on 2026-09-16, so these old versions of actions/download-artifact and actions/upload-artifact will probably stop working then. actions/download-artifact v8 and actions/upload-artifact v7 explicitly depend on Node.js v24, so upgrade to those versions - there don't appear to be any backwards-incompatible changes.