### PR TITLE
GHA: upgrade cross-platform-actions/action to v1.0.0

### DIFF
--- a/.github/workflows/please_pex_build.yaml
+++ b/.github/workflows/please_pex_build.yaml
@@ -28,7 +28,7 @@ jobs:
             }
       - name: Build please_pex binary (on freebsd-builder image)
         if: ${{ inputs.platform == 'freebsd_amd64' }}
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: freebsd
           architecture: x86-64

--- a/.github/workflows/plugin_test.yaml
+++ b/.github/workflows/plugin_test.yaml
@@ -45,7 +45,7 @@ jobs:
         run: echo "PLZ_ARGS=${PLZ_ARGS:+$PLZ_ARGS }-o plugin.python.pextool://tools/please_pex -e plz_e2e_test" >> $GITHUB_ENV
       - name: Run tests (in nested runner)
         if: ${{ inputs.platform == 'freebsd_amd64' }}
-        uses: cross-platform-actions/action@v0.30.0
+        uses: cross-platform-actions/action@v1.0.0
         with:
           operating_system: freebsd
           architecture: x86-64


### PR DESCRIPTION
v0.30.0 depends on Node.js v20, which will be removed from GitHub-hosted runners on 2026-09-16. v1.0.0 is the first release to depend on Node.js v24. There are other breaking changes since v0.30.0, but none that affect how the action is used in this repo.