### PR TITLE
GHA: bump Docker action versions

### DIFF
--- a/.github/workflows/please_pex_build.yaml
+++ b/.github/workflows/please_pex_build.yaml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/checkout@v6
       - name: Set up QEMU
         if: ${{ startsWith(inputs.platform, 'linux_') }}
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker
         if: ${{ startsWith(inputs.platform, 'linux_') }}
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
         with:
           daemon-config: |
             {


### PR DESCRIPTION
Bump docker/setup-docker-action to v5 and docker/setup-qemu-action to v4. These are the first versions to depend on Node.js v24 instead of Node.js v20, which will be removed from GitHub-hosted runners on 2026-09-16. Despite the major version bumps, there are no breaking changes in either action, so these should be safe upgrades.